### PR TITLE
fix npc shop prices

### DIFF
--- a/generic/src/main/java/net/swofty/types/generic/item/ItemType.java
+++ b/generic/src/main/java/net/swofty/types/generic/item/ItemType.java
@@ -752,7 +752,7 @@ public enum ItemType {
     ENCHANTED_DIAMOND_BLOCK(Material.DIAMOND_BLOCK, Rarity.UNCOMMON, EnchantedDiamondBlock.class),
     ENCHANTED_EMERALD_BLOCK(Material.EMERALD_BLOCK, Rarity.UNCOMMON, EnchantedEmeraldBlock.class),
     ENCHANTED_GOLD_INGOT(Material.GOLD_INGOT, Rarity.UNCOMMON, EnchantedGold.class),
-    ENCHANTED_GOLD_BLOCK(Material.GOLD_BLOCK, Rarity.UNCOMMON, EnchantedGoldBlock.class),
+    ENCHANTED_GOLD_BLOCK(Material.GOLD_BLOCK, Rarity.RARE, EnchantedGoldBlock.class),
     ENCHANTED_JUNGLE_WOOD(Material.JUNGLE_LOG, Rarity.UNCOMMON, EnchantedJungleWood.class),
     ENCHANTED_GUNPOWDER(Material.GUNPOWDER, Rarity.UNCOMMON, EnchantedGunpowder.class),
     ENCHANTED_IRON_INGOT(Material.IRON_INGOT, Rarity.UNCOMMON, EnchantedIron.class),

--- a/generic/src/main/java/net/swofty/types/generic/mission/MissionData.java
+++ b/generic/src/main/java/net/swofty/types/generic/mission/MissionData.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
 import net.swofty.types.generic.calendar.SkyBlockCalendar;
-import net.swofty.types.generic.mission.missions.MissionTalkToVillagers;
 import net.swofty.types.generic.region.RegionType;
 import net.swofty.types.generic.user.SkyBlockPlayer;
 import org.jetbrains.annotations.Nullable;

--- a/generic/src/main/java/net/swofty/types/generic/mission/missions/MissionKillZombies.java
+++ b/generic/src/main/java/net/swofty/types/generic/mission/missions/MissionKillZombies.java
@@ -1,0 +1,69 @@
+package net.swofty.types.generic.mission.missions;
+
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.event.Event;
+import net.swofty.types.generic.event.EventNodes;
+import net.swofty.types.generic.event.EventParameters;
+import net.swofty.types.generic.event.custom.PlayerKilledSkyBlockMobEvent;
+import net.swofty.types.generic.mission.MissionData;
+import net.swofty.types.generic.mission.SkyBlockProgressMission;
+import net.swofty.types.generic.region.RegionType;
+import net.swofty.types.generic.user.SkyBlockPlayer;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@EventParameters(description = "Kill Zombies mission",
+    node = EventNodes.CUSTOM,
+    requireDataLoaded = true)
+public class MissionKillZombies extends SkyBlockProgressMission {
+    @Override
+    public Class<? extends Event> getEvent() {
+        return PlayerKilledSkyBlockMobEvent.class;
+    }
+
+    @Override
+    public void run(Event tempEvent) {
+        PlayerKilledSkyBlockMobEvent event = (PlayerKilledSkyBlockMobEvent) tempEvent;
+        if (event.getKilledMob().getEntityType() != EntityType.ZOMBIE) return;
+
+        MissionData data = event.getPlayer().getMissionData();
+        if (!data.isCurrentlyActive(MissionKillZombies.class) || data.hasCompleted(MissionKillZombies.class)) return;
+
+        MissionData.ActiveMission mission = data.getMission(MissionKillZombies.class).getKey();
+        mission.setMissionProgress(mission.getMissionProgress() + 1);
+        mission.checkIfMissionEnded(event.getPlayer());
+    }
+
+    @Override
+    public String getID() {
+        return "kill_zombies";
+    }
+
+    @Override
+    public String getName() {
+        return "Kill Zombies";
+    }
+
+    @Override
+    public Map<String, Object> onStart(SkyBlockPlayer player, MissionData.ActiveMission mission) {
+        return new HashMap<>();
+    }
+
+    @Override
+    public void onEnd(SkyBlockPlayer player, Map<String, Object> customData, MissionData.ActiveMission mission) {
+        //TODO move bartender to the bar
+    }
+
+    @Override
+    public Set<RegionType> getValidRegions() {
+        return Collections.singleton(RegionType.GRAVEYARD);
+    }
+
+    @Override
+    public int getMaxProgress() {
+        return 12;
+    }
+}

--- a/type-village/src/main/java/net/swofty/type/village/gui/GUIShopLumberMerchant.java
+++ b/type-village/src/main/java/net/swofty/type/village/gui/GUIShopLumberMerchant.java
@@ -1,12 +1,10 @@
 package net.swofty.type.village.gui;
 
-import net.minestom.server.inventory.Inventory;
 import net.minestom.server.item.Material;
 import net.swofty.types.generic.gui.inventory.SkyBlockShopGUI;
 import net.swofty.types.generic.item.ItemType;
 import net.swofty.types.generic.item.SkyBlockItem;
 import net.swofty.types.generic.shop.type.CoinShopPrice;
-import net.swofty.types.generic.user.SkyBlockPlayer;
 
 public class GUIShopLumberMerchant extends SkyBlockShopGUI {
     public GUIShopLumberMerchant() {
@@ -15,13 +13,13 @@ public class GUIShopLumberMerchant extends SkyBlockShopGUI {
 
     @Override
     public void initializeShopItems() {
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.OAK_LOG), 5, new CoinShopPrice(25), 1));
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.BIRCH_LOG), 5, new CoinShopPrice(25), 1));
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.SPRUCE_LOG), 5, new CoinShopPrice(25), 1));
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.DARK_OAK_LOG), 5, new CoinShopPrice(25), 1));
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.ACACIA_LOG), 5, new CoinShopPrice(25), 1));
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.JUNGLE_LOG), 5, new CoinShopPrice(25), 1));
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.STICK), 32, new CoinShopPrice(20), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.OAK_LOG), 5, new CoinShopPrice(5), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.BIRCH_LOG), 5, new CoinShopPrice(5), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.SPRUCE_LOG), 5, new CoinShopPrice(5), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.DARK_OAK_LOG), 5, new CoinShopPrice(5), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.ACACIA_LOG), 5, new CoinShopPrice(5), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.JUNGLE_LOG), 5, new CoinShopPrice(5), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.STICK), 32, new CoinShopPrice(0.6), 1));
         attachItem(ShopItem.Single(new SkyBlockItem(ItemType.ROOKIE_AXE), 1, new CoinShopPrice(12), 1));
         attachItem(ShopItem.Single(new SkyBlockItem(ItemType.PROMISING_AXE), 1, new CoinShopPrice(35), 1));
         attachItem(ShopItem.Stackable(new SkyBlockItem(Material.PODZOL), 1, new CoinShopPrice(20), 1));

--- a/type-village/src/main/java/net/swofty/type/village/gui/GUIShopMineMerchant.java
+++ b/type-village/src/main/java/net/swofty/type/village/gui/GUIShopMineMerchant.java
@@ -1,13 +1,11 @@
 package net.swofty.type.village.gui;
 
-import net.minestom.server.inventory.Inventory;
 import net.minestom.server.item.Material;
 import net.swofty.types.generic.gui.inventory.SkyBlockShopGUI;
 import net.swofty.types.generic.item.ItemType;
 import net.swofty.types.generic.item.SkyBlockItem;
 import net.swofty.types.generic.shop.type.CoinShopPrice;
 import net.swofty.types.generic.shop.type.ItemShopPrice;
-import net.swofty.types.generic.user.SkyBlockPlayer;
 
 public class GUIShopMineMerchant extends SkyBlockShopGUI{
     public GUIShopMineMerchant() {
@@ -16,16 +14,16 @@ public class GUIShopMineMerchant extends SkyBlockShopGUI{
 
     @Override
     public void initializeShopItems() {
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.COAL), 2, new CoinShopPrice(8), 1));
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.IRON_INGOT), 4, new CoinShopPrice(22), 1));
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.GOLD_INGOT), 2, new CoinShopPrice(12), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.COAL), 2, new CoinShopPrice(4), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.IRON_INGOT), 4, new CoinShopPrice(5.5), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.GOLD_INGOT), 2, new CoinShopPrice(6), 1));
         attachItem(ShopItem.Single(new SkyBlockItem(ItemType.ROOKIE_PICKAXE), 1, new CoinShopPrice(12), 1));
         attachItem(ShopItem.Single(new SkyBlockItem(ItemType.PROMISING_PICKAXE), 1, new CoinShopPrice(35), 1));
         attachItem(ShopItem.Single(new SkyBlockItem(Material.GOLDEN_PICKAXE), 1, new ItemShopPrice(ItemType.GOLD_INGOT, 3), 1));
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.TORCH), 32, new CoinShopPrice(16), 1));
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.GRAVEL), 2, new CoinShopPrice(12), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.TORCH), 32, new CoinShopPrice(0.5), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.GRAVEL), 2, new CoinShopPrice(6), 1));
         attachItem(ShopItem.Stackable(new SkyBlockItem(Material.COBBLESTONE), 1, new CoinShopPrice(3), 1));
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.STONE), 2, new CoinShopPrice(4), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.STONE), 2, new CoinShopPrice(2), 1));
         //attachItem(ShopItem.Single(new SkyBlockItem(Material.ONYX), 1, new CoinShopPrice(100), 1));
     }
 

--- a/type-village/src/main/java/net/swofty/type/village/gui/GUIShopPat.java
+++ b/type-village/src/main/java/net/swofty/type/village/gui/GUIShopPat.java
@@ -12,7 +12,7 @@ public class GUIShopPat extends SkyBlockShopGUI {
 
     @Override
     public void initializeShopItems() {
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.FLINT), 10, new CoinShopPrice(60), 1));
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.GRAVEL), 15, new CoinShopPrice(65), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.FLINT), 10, new CoinShopPrice(6), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.GRAVEL), 15, new CoinShopPrice(4.3), 1));
     }
 }

--- a/type-village/src/main/java/net/swofty/type/village/gui/GUIShopWeaponsmith.java
+++ b/type-village/src/main/java/net/swofty/type/village/gui/GUIShopWeaponsmith.java
@@ -1,12 +1,10 @@
 package net.swofty.type.village.gui;
 
-import net.minestom.server.inventory.Inventory;
 import net.minestom.server.item.Material;
 import net.swofty.types.generic.gui.inventory.SkyBlockShopGUI;
 import net.swofty.types.generic.item.ItemType;
 import net.swofty.types.generic.item.SkyBlockItem;
 import net.swofty.types.generic.shop.type.CoinShopPrice;
-import net.swofty.types.generic.user.SkyBlockPlayer;
 
 public class GUIShopWeaponsmith extends SkyBlockShopGUI{
 
@@ -21,7 +19,7 @@ public class GUIShopWeaponsmith extends SkyBlockShopGUI{
         attachItem(ShopItem.Single(new SkyBlockItem(ItemType.SPIDER_SWORD), 1, new CoinShopPrice(100), 1));
         attachItem(ShopItem.Single(new SkyBlockItem(Material.DIAMOND_SWORD), 1, new CoinShopPrice(60), 1));
         attachItem(ShopItem.Single(new SkyBlockItem(Material.BOW), 1, new CoinShopPrice(25), 1));
-        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.ARROW), 12, new CoinShopPrice(40), 1));
+        attachItem(ShopItem.Stackable(new SkyBlockItem(Material.ARROW), 1, new CoinShopPrice(3), 1));
         attachItem(ShopItem.Single(new SkyBlockItem(ItemType.WITHER_BOW), 1, new CoinShopPrice(250), 1));
         attachItem(ShopItem.Single(new SkyBlockItem(ItemType.ARTISANAL_SHORTBOW), 1, new CoinShopPrice(600), 1));
     }

--- a/type-village/src/main/java/net/swofty/type/village/npcs/NPCBartender.java
+++ b/type-village/src/main/java/net/swofty/type/village/npcs/NPCBartender.java
@@ -1,10 +1,14 @@
 package net.swofty.type.village.npcs;
 
 import net.minestom.server.coordinate.Pos;
+import net.swofty.types.generic.entity.npc.NPCDialogue;
 import net.swofty.types.generic.entity.npc.NPCParameters;
-import net.swofty.types.generic.entity.npc.SkyBlockNPC;
+import net.swofty.types.generic.mission.MissionData;
+import net.swofty.types.generic.mission.missions.MissionKillZombies;
 
-public class NPCBartender extends SkyBlockNPC {
+import java.util.stream.Stream;
+
+public class NPCBartender extends NPCDialogue {
 
     public NPCBartender() {
         super(new NPCParameters() {
@@ -37,7 +41,28 @@ public class NPCBartender extends SkyBlockNPC {
 
     @Override
     public void onClick(PlayerClickNPCEvent e) {
-        e.player().sendMessage("§cThis Feature is not there yet. §aOpen a Pull request at https://github.com/Swofty-Developments/HypixelSkyBlock to get it added quickly!");
+        if (e.player().getMissionData().isCurrentlyActive(MissionKillZombies.class)) {
+            setDialogue(e.player(), "quest-talk");
+            return;
+        }
+        setDialogue(e.player(), "quest-hello");
+        MissionData data = e.player().getMissionData();
+        data.startMission(MissionKillZombies.class);
     }
 
+    @Override
+    public DialogueSet[] getDialogueSets() {
+        return Stream.of(
+                DialogueSet.builder()
+                        .key("quest-hello").lines(new String[]{
+                            "§e[NPC] Bartender: §fWelcome to the Bar, friend!",
+                            "§e[NPC] Bartender: §fThese are trying times, indeed. The §cGraveyard §fis overflowing with monsters! Anyone who comes in is spooked off by the grunts of zombies in the distance.",
+                            "§e[NPC] Bartender: §fCould you give me a hand? If you help clear out some of these monsters, I'll pay you for it."
+                        }).build(),
+                DialogueSet.builder()
+                        .key("quest-talk").lines(new String[]{
+                            "§e[NPC] Bartender: §fClear out some more of those Zombies and I'll pay you greatly for it!"
+                        }).build()
+        ).toArray(NPCDialogue.DialogueSet[]::new);
+    }
 }


### PR DESCRIPTION
Items that by default are bought in multiples had incorrect prices, for example buying 10 flint costs 600 coins when it should be costing 60