### PR TITLE
Update version of NanoLimbo on DockerFile

### DIFF
--- a/DockerFiles/Dockerfile.game_server
+++ b/DockerFiles/Dockerfile.game_server
@@ -33,7 +33,7 @@ RUN unzip world.zip -d ./configuration && rm world.zip
 EXPOSE 25565 65535 8080 20000
 
 # Copy NanoLimbo
-RUN cp configuration_files/NanoLimbo-1.8.1.jar ./NanoLimbo-1.8.1.jar
+RUN cp configuration_files/NanoLimbo-1.9.1-all.jar ./NanoLimbo-1.9.1-all.jar
 
 # Copy the Nano Config
 RUN cp configuration_files/settings.yml ./settings.yml


### PR DESCRIPTION
This PR fixes an issue with building the containers as the NanoVersion was updated, but not updated in the DockerFile itself

![Screenshot 2025-05-27 at 17 07 02](https://github.com/user-attachments/assets/be3cc361-1794-4c61-8993-8d5a1ae53e79)
