### PR TITLE
Update GUIClickableItems to use HypixelPlayer

### DIFF
--- a/type.hub/src/main/java/net/swofty/type/hub/gui/GUIBiblio.java
+++ b/type.hub/src/main/java/net/swofty/type/hub/gui/GUIBiblio.java
@@ -23,13 +23,14 @@ public class GUIBiblio extends HypixelInventoryGUI {
         set(GUIClickableItem.getCloseItem(31));
         set(new GUIClickableItem(11) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                player.sendMessage(Component.text("§7Click §e§lHERE §7to visit the §6Official SkyBlock Wiki§7!§r")
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                skyBlockPlayer.sendMessage(Component.text("§7Click §e§lHERE §7to visit the §6Official SkyBlock Wiki§7!§r")
                         .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://wiki.hypixel.net")));
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§dWiki Command", Material.PAINTING, 1,
                         "§7Visit the Wiki using §a/wiki §7and browse", "§7the many pages and utilities.",
                         "", "§7You can also specify an extra", "§7argument when using §6/wiki <id> §7to",
@@ -38,12 +39,12 @@ public class GUIBiblio extends HypixelInventoryGUI {
         });
         set(new GUIClickableItem(13) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
 
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§6The Skyblock Wiki", Material.WRITABLE_BOOK, 1,
                         "§7The newly finished §aOfficial SkyBlock", "§aWiki §7has launched and contains lots",
                         "§7of useful information on items, mobs,", "§7drop rates, areas, trivia, and more.",
@@ -55,13 +56,14 @@ public class GUIBiblio extends HypixelInventoryGUI {
         });
         set(new GUIClickableItem(15) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                player.sendMessage(Component.text("§cThis Feature is not there yet. §aOpen a Pull request HERE to get it added quickly!")
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                skyBlockPlayer.sendMessage(Component.text("§cThis Feature is not there yet. §aOpen a Pull request HERE to get it added quickly!")
                         .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://github.com/Swofty-Developments/HypixelSkyBlock")));
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aWikithis Command", Material.OAK_SIGN, 1,
                         "§7Want to view more information about",
                         "§7the item you are currently §dholding §7?", "§7Then this is the command for §eyou§7!",
@@ -82,7 +84,7 @@ public class GUIBiblio extends HypixelInventoryGUI {
     }
 
     @Override
-    public void suddenlyQuit(Inventory inventory, SkyBlockPlayer player) {
+    public void suddenlyQuit(Inventory inventory, HypixelPlayer player) {
     }
 
     @Override

--- a/type.hub/src/main/java/net/swofty/type/hub/gui/GUIGeorge.java
+++ b/type.hub/src/main/java/net/swofty/type/hub/gui/GUIGeorge.java
@@ -19,6 +19,7 @@ import net.swofty.type.skyblockgeneric.item.components.PetComponent;
 import net.swofty.type.skyblockgeneric.item.components.PetItemComponent;
 import net.swofty.type.skyblockgeneric.item.updater.PlayerItemUpdater;
 import net.swofty.type.skyblockgeneric.user.SkyBlockPlayer;
+import net.swofty.type.generic.user.HypixelPlayer;
 
 public class GUIGeorge extends HypixelInventoryGUI {
 
@@ -41,7 +42,7 @@ public class GUIGeorge extends HypixelInventoryGUI {
         if (item == null) {
             set(new GUIClickableItem(13) {
                 @Override
-                public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+                public void run(InventoryPreClickEvent e, HypixelPlayer player) {
                     ItemStack stack = e.getCursorItem();
 
                     if (stack.get(ItemComponent.CUSTOM_NAME) == null) {
@@ -59,18 +60,19 @@ public class GUIGeorge extends HypixelInventoryGUI {
                 }
 
                 @Override
-                public ItemStack.Builder getItem(SkyBlockPlayer player) {
+                public ItemStack.Builder getItem(HypixelPlayer player) {
                     return ItemStack.builder(Material.AIR);
                 }
             });
             set(new GUIClickableItem(22) {
                 @Override
-                public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                    player.sendMessage("§cPlace a pet in the empty slot for George to evaluate it!");
+                public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                    SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                    skyBlockPlayer.sendMessage("§cPlace a pet in the empty slot for George to evaluate it!");
                 }
 
                 @Override
-                public ItemStack.Builder getItem(SkyBlockPlayer player) {
+                public ItemStack.Builder getItem(HypixelPlayer player) {
                     return ItemStackCreator.getStack(
                             "§eOffer a Pet", Material.RED_TERRACOTTA, 1,
                             "§7Place a pet above and George will",
@@ -84,25 +86,27 @@ public class GUIGeorge extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(13) {
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
-                return PlayerItemUpdater.playerUpdate(player , item.getItemStack());
+            public ItemStack.Builder getItem(HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                return PlayerItemUpdater.playerUpdate(skyBlockPlayer , item.getItemStack());
             }
 
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 ItemStack stack = e.getClickedItem();
                 if (stack.isAir()) return;
 
                 updateFromItem(null);
 
-                player.addAndUpdateItem(stack);
+                skyBlockPlayer.addAndUpdateItem(stack);
             }
         });
 
         if (item.getAmount() > 1 || item.hasComponent(PetItemComponent.class)) {
             set(new GUIItem(22) {
                 @Override
-                public ItemStack.Builder getItem(SkyBlockPlayer player) {
+                public ItemStack.Builder getItem(HypixelPlayer player) {
                     return ItemStackCreator.getStack(
                             "§cError!", Material.BARRIER, 1,
                             "§7George only wants to buy pets!"
@@ -115,8 +119,9 @@ public class GUIGeorge extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(22) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                DatapointDouble coins = player.getSkyBlockData().get(SkyBlockDataHandler.Data.COINS, DatapointDouble.class);
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                DatapointDouble coins = skyBlockPlayer.getSkyBlockData().get(SkyBlockDataHandler.Data.COINS, DatapointDouble.class);
                 Rarity rarity = item.getAttributeHandler().getRarity();
                 PetComponent petComponent = item.getComponent(PetComponent.class);
                 Integer price = petComponent.getGeorgePrice().getForRarity(rarity);
@@ -128,7 +133,8 @@ public class GUIGeorge extends HypixelInventoryGUI {
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 return ItemStackCreator.getStack(
                         "§aAccept Offer", Material.GREEN_TERRACOTTA, 1,
                         "§7George is willing to make an offer on",
@@ -159,8 +165,9 @@ public class GUIGeorge extends HypixelInventoryGUI {
     }
 
     @Override
-    public void suddenlyQuit(Inventory inventory, SkyBlockPlayer player) {
-        player.addAndUpdateItem(new SkyBlockItem(inventory.getItemStack(13)));
+    public void suddenlyQuit(Inventory inventory, HypixelPlayer player) {
+        SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+        skyBlockPlayer.addAndUpdateItem(new SkyBlockItem(inventory.getItemStack(13)));
     }
 
     @Override

--- a/type.hub/src/main/java/net/swofty/type/hub/gui/GUIHubSelector.java
+++ b/type.hub/src/main/java/net/swofty/type/hub/gui/GUIHubSelector.java
@@ -16,6 +16,7 @@ import net.swofty.type.generic.gui.inventory.RefreshingGUI;
 import net.swofty.type.generic.gui.inventory.HypixelPaginatedGUI;
 import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
 import net.swofty.type.skyblockgeneric.user.SkyBlockPlayer;
+import net.swofty.type.generic.user.HypixelPlayer;
 import net.swofty.type.generic.utility.PaginationList;
 
 import java.util.Comparator;
@@ -46,7 +47,7 @@ public class GUIHubSelector extends HypixelPaginatedGUI<UnderstandableProxyServe
     }
 
     @Override
-    protected PaginationList<UnderstandableProxyServer> fillPaged(SkyBlockPlayer player, PaginationList<UnderstandableProxyServer> paged) {
+    protected PaginationList<UnderstandableProxyServer> fillPaged(HypixelPlayer player, PaginationList<UnderstandableProxyServer> paged) {
         fill(ItemStackCreator.createNamedItemStack(Material.BLACK_STAINED_GLASS_PANE));
         servers = information.getServerInformation(ServerType.SKYBLOCK_HUB).join();
         paged.addAll(servers);
@@ -54,11 +55,12 @@ public class GUIHubSelector extends HypixelPaginatedGUI<UnderstandableProxyServe
         set(GUIClickableItem.getCloseItem(49));
         set(new GUIClickableItem(50) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 ClickType clickType = e.getClickType();
 
                 if (sending) {
-                    player.sendMessage("§cWe are currently trying to queue you into another server!");
+                    skyBlockPlayer.sendMessage("§cWe are currently trying to queue you into another server!");
                     return;
                 }
 
@@ -68,7 +70,7 @@ public class GUIHubSelector extends HypixelPaginatedGUI<UnderstandableProxyServe
                         .toList();
 
                 if (serversToUse.isEmpty()) {
-                    player.sendMessage("§cNo servers with enough players found!");
+                    skyBlockPlayer.sendMessage("§cNo servers with enough players found!");
                     return;
                 }
 
@@ -84,9 +86,9 @@ public class GUIHubSelector extends HypixelPaginatedGUI<UnderstandableProxyServe
                             .orTimeout(3, TimeUnit.SECONDS)
                             .exceptionally(throwable -> {
                                 if (throwable instanceof TimeoutException) {
-                                    player.sendMessage("§cYour transfer failed! The server took too long to respond.");
+                                    skyBlockPlayer.sendMessage("§cYour transfer failed! The server took too long to respond.");
                                 } else {
-                                    player.sendMessage("§cYour transfer failed! An error occurred.");
+                                    skyBlockPlayer.sendMessage("§cYour transfer failed! An error occurred.");
                                 }
                                 sending = false;
                                 return null; // Return value for the CompletableFuture
@@ -102,9 +104,9 @@ public class GUIHubSelector extends HypixelPaginatedGUI<UnderstandableProxyServe
                         .orTimeout(3, TimeUnit.SECONDS)
                         .exceptionally(throwable -> {
                             if (throwable instanceof TimeoutException) {
-                                player.sendMessage("§cYour transfer failed! The server took too long to respond.");
+                                skyBlockPlayer.sendMessage("§cYour transfer failed! The server took too long to respond.");
                             } else {
-                                player.sendMessage("§cYour transfer failed! An error occurred.");
+                                skyBlockPlayer.sendMessage("§cYour transfer failed! An error occurred.");
                             }
                             sending = false;
                             return null; // Return value for the CompletableFuture
@@ -112,7 +114,7 @@ public class GUIHubSelector extends HypixelPaginatedGUI<UnderstandableProxyServe
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack(
                         "§aRandom Hub",
                         Material.COMPASS, 1,
@@ -137,16 +139,16 @@ public class GUIHubSelector extends HypixelPaginatedGUI<UnderstandableProxyServe
     }
 
     @Override
-    protected void performSearch(SkyBlockPlayer player, String query, int page, int maxPage) {
+    protected void performSearch(HypixelPlayer player, String query, int page, int maxPage) {
     }
 
     @Override
-    protected String getTitle(SkyBlockPlayer player, String query, int page, PaginationList<UnderstandableProxyServer> paged) {
+    protected String getTitle(HypixelPlayer player, String query, int page, PaginationList<UnderstandableProxyServer> paged) {
         return "SkyBlock Hub Selector";
     }
 
     @Override
-    protected GUIClickableItem createItemFor(UnderstandableProxyServer server, int slot, SkyBlockPlayer player) {
+    protected GUIClickableItem createItemFor(UnderstandableProxyServer server, int slot, HypixelPlayer player) {
         boolean isThisServer = server.port() == SkyBlockConst.getPort();
         boolean isFull = server.players().size() >= server.maxPlayers();
 
@@ -154,7 +156,7 @@ public class GUIHubSelector extends HypixelPaginatedGUI<UnderstandableProxyServe
             private int counterAtThisMoment;
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 counter++;
                 counterAtThisMoment = counter;
                 return ItemStackCreator.getStack(
@@ -169,20 +171,21 @@ public class GUIHubSelector extends HypixelPaginatedGUI<UnderstandableProxyServe
             }
 
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 if (isThisServer) {
-                    player.sendMessage("§cYou are already on this server!");
+                    skyBlockPlayer.sendMessage("§cYou are already on this server!");
                     player.closeInventory();
                     return;
                 }
 
                 if (isFull) {
-                    player.sendMessage("§cYou cannot join this server because it is full!");
+                    skyBlockPlayer.sendMessage("§cYou cannot join this server because it is full!");
                     return;
                 }
 
                 if (sending) {
-                    player.sendMessage("§cWe are currently trying to queue you into another server!");
+                    skyBlockPlayer.sendMessage("§cWe are currently trying to queue you into another server!");
                     return;
                 }
 
@@ -193,9 +196,9 @@ public class GUIHubSelector extends HypixelPaginatedGUI<UnderstandableProxyServe
                         .orTimeout(3, TimeUnit.SECONDS)
                         .exceptionally(throwable -> {
                             if (throwable instanceof TimeoutException) {
-                                player.sendMessage("§cYour transfer failed! The server took too long to respond.");
+                                skyBlockPlayer.sendMessage("§cYour transfer failed! The server took too long to respond.");
                             } else {
-                                player.sendMessage("§cYour transfer failed! An error occurred.");
+                                skyBlockPlayer.sendMessage("§cYour transfer failed! An error occurred.");
                             }
                             sending = false;
                             return null; // Return value for the CompletableFuture
@@ -215,7 +218,7 @@ public class GUIHubSelector extends HypixelPaginatedGUI<UnderstandableProxyServe
     }
 
     @Override
-    public void refreshItems(SkyBlockPlayer player) {
+    public void refreshItems(HypixelPlayer player) {
         servers = information.getServerInformation(ServerType.SKYBLOCK_HUB).join();
         PaginationList<UnderstandableProxyServer> paged = fillPaged(player, new PaginationList<>(getPaginatedSlots().length));
         int page = 1;

--- a/type.hub/src/main/java/net/swofty/type/hub/gui/GUIJamie.java
+++ b/type.hub/src/main/java/net/swofty/type/hub/gui/GUIJamie.java
@@ -12,6 +12,7 @@ import net.swofty.type.generic.gui.inventory.ItemStackCreator;
 import net.swofty.type.generic.gui.inventory.HypixelInventoryGUI;
 import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
 import net.swofty.type.skyblockgeneric.user.SkyBlockPlayer;
+import net.swofty.type.generic.user.HypixelPlayer;
 
 public class GUIJamie extends HypixelInventoryGUI {
     public GUIJamie() {
@@ -24,14 +25,15 @@ public class GUIJamie extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(22) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                player.addAndUpdateItem(ItemType.ROGUE_SWORD);
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                skyBlockPlayer.addAndUpdateItem(ItemType.ROGUE_SWORD);
                 player.closeInventory();
-                player.sendMessage(Component.text("§aYou claimed a §fRogue Sword§a!"));
+                skyBlockPlayer.sendMessage(Component.text("§aYou claimed a §fRogue Sword§a!"));
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§fRogue Sword", Material.GOLDEN_SWORD, 1,
                         "§7Damage: §c+20",
                         "",
@@ -58,7 +60,7 @@ public class GUIJamie extends HypixelInventoryGUI {
     }
 
     @Override
-    public void suddenlyQuit(Inventory inventory, SkyBlockPlayer player) {
+    public void suddenlyQuit(Inventory inventory, HypixelPlayer player) {
     }
 
     @Override

--- a/type.hub/src/main/java/net/swofty/type/hub/gui/GUIMaxwell.java
+++ b/type.hub/src/main/java/net/swofty/type/hub/gui/GUIMaxwell.java
@@ -28,12 +28,12 @@ public class GUIMaxwell extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(47) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
                 new GUIAccessoryBag().open(player);
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStackHead("§aAccessory Bag Shortcut", "961a918c0c49ba8d053e522cb91abc74689367b4d8aa06bfc1ba9154730985ff", 1,
                         "§7Quickly access your accessory bag",
                         "§7from right here!",
@@ -43,15 +43,16 @@ public class GUIMaxwell extends HypixelInventoryGUI {
         });
         set(new GUIItem(48) {
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
-                int mythic = player.getAccessoryBag().getUniqueAccessories(Rarity.MYTHIC).size();
-                int legendary = player.getAccessoryBag().getUniqueAccessories(Rarity.LEGENDARY).size();
-                int epic = player.getAccessoryBag().getUniqueAccessories(Rarity.EPIC).size();
-                int rare = player.getAccessoryBag().getUniqueAccessories(Rarity.RARE).size();
-                int uncommon = player.getAccessoryBag().getUniqueAccessories(Rarity.UNCOMMON).size();
-                int common = player.getAccessoryBag().getUniqueAccessories(Rarity.COMMON).size();
-                int special = player.getAccessoryBag().getUniqueAccessories(Rarity.SPECIAL).size();
-                int verySpecial = player.getAccessoryBag().getUniqueAccessories(Rarity.VERY_SPECIAL).size();
+            public ItemStack.Builder getItem(HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                int mythic = skyBlockPlayer.getAccessoryBag().getUniqueAccessories(Rarity.MYTHIC).size();
+                int legendary = skyBlockPlayer.getAccessoryBag().getUniqueAccessories(Rarity.LEGENDARY).size();
+                int epic = skyBlockPlayer.getAccessoryBag().getUniqueAccessories(Rarity.EPIC).size();
+                int rare = skyBlockPlayer.getAccessoryBag().getUniqueAccessories(Rarity.RARE).size();
+                int uncommon = skyBlockPlayer.getAccessoryBag().getUniqueAccessories(Rarity.UNCOMMON).size();
+                int common = skyBlockPlayer.getAccessoryBag().getUniqueAccessories(Rarity.COMMON).size();
+                int special = skyBlockPlayer.getAccessoryBag().getUniqueAccessories(Rarity.SPECIAL).size();
+                int verySpecial = skyBlockPlayer.getAccessoryBag().getUniqueAccessories(Rarity.VERY_SPECIAL).size();
 
                 return ItemStackCreator.getStack("§aAccessories Breakdown", Material.FILLED_MAP, 1,
                         "§8From your bag",
@@ -81,7 +82,7 @@ public class GUIMaxwell extends HypixelInventoryGUI {
     }
 
     @Override
-    public void suddenlyQuit(Inventory inventory, SkyBlockPlayer player) {
+    public void suddenlyQuit(Inventory inventory, HypixelPlayer player) {
     }
 
     @Override

--- a/type.hub/src/main/java/net/swofty/type/hub/gui/GUIMaxwell.java
+++ b/type.hub/src/main/java/net/swofty/type/hub/gui/GUIMaxwell.java
@@ -14,6 +14,7 @@ import net.swofty.type.skyblockgeneric.gui.inventories.sbmenu.bags.GUIAccessoryB
 import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
 import net.swofty.type.generic.gui.inventory.item.GUIItem;
 import net.swofty.type.skyblockgeneric.user.SkyBlockPlayer;
+import net.swofty.type.generic.user.HypixelPlayer;
 
 public class GUIMaxwell extends HypixelInventoryGUI {
 

--- a/type.hub/src/main/java/net/swofty/type/hub/gui/GUISeymour.java
+++ b/type.hub/src/main/java/net/swofty/type/hub/gui/GUISeymour.java
@@ -29,20 +29,22 @@ public class GUISeymour extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(11) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                double coins = player.getCoins();
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                double coins = skyBlockPlayer.getCoins();
                 if (coins < cheapTuxedoPrice) {
                     return;
                 }
-                player.addAndUpdateItem(ItemType.CHEAP_TUXEDO_CHESTPLATE);
-                player.addAndUpdateItem(ItemType.CHEAP_TUXEDO_BOOTS);
-                player.addAndUpdateItem(ItemType.CHEAP_TUXEDO_LEGGINGS);
-                player.playSuccessSound();
-                player.removeCoins(cheapTuxedoPrice);
+                skyBlockPlayer.addAndUpdateItem(ItemType.CHEAP_TUXEDO_CHESTPLATE);
+                skyBlockPlayer.addAndUpdateItem(ItemType.CHEAP_TUXEDO_BOOTS);
+                skyBlockPlayer.addAndUpdateItem(ItemType.CHEAP_TUXEDO_LEGGINGS);
+                skyBlockPlayer.playSuccessSound();
+                skyBlockPlayer.removeCoins(cheapTuxedoPrice);
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 ItemStack.Builder builder = ItemStackCreator.getStack("§5Cheap Tuxedo", Material.LEATHER_CHESTPLATE, 1,
                         "",
                         "§8Complete suit",
@@ -56,7 +58,7 @@ public class GUISeymour extends HypixelInventoryGUI {
                         "",
                         "§7Cost: §6" + StringUtility.commaify(cheapTuxedoPrice) + " Coins",
                         "",
-                        player.getCoins() >= cheapTuxedoPrice ? "§eClick to purchase" : "§cCan't afford this!"
+                        skyBlockPlayer.getCoins() >= cheapTuxedoPrice ? "§eClick to purchase" : "§cCan't afford this!"
                 );
 
                 builder.set(ItemComponent.DYED_COLOR, new DyedItemColor(new Color(56, 56, 56)));
@@ -66,20 +68,22 @@ public class GUISeymour extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(13) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                double coins = player.getCoins();
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                double coins = skyBlockPlayer.getCoins();
                 if (coins < fancyTuxedoPrice) {
                     return;
                 }
-                player.addAndUpdateItem(ItemType.FANCY_TUXEDO_CHESTPLATE);
-                player.addAndUpdateItem(ItemType.FANCY_TUXEDO_BOOTS);
-                player.addAndUpdateItem(ItemType.FANCY_TUXEDO_LEGGINGS);
-                player.playSuccessSound();
-                player.removeCoins(fancyTuxedoPrice);
+                skyBlockPlayer.addAndUpdateItem(ItemType.FANCY_TUXEDO_CHESTPLATE);
+                skyBlockPlayer.addAndUpdateItem(ItemType.FANCY_TUXEDO_BOOTS);
+                skyBlockPlayer.addAndUpdateItem(ItemType.FANCY_TUXEDO_LEGGINGS);
+                skyBlockPlayer.playSuccessSound();
+                skyBlockPlayer.removeCoins(fancyTuxedoPrice);
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 ItemStack.Builder builder = ItemStackCreator.getStack("§6Fancy Tuxedo", Material.LEATHER_CHESTPLATE, 1,
                         "",
                         "§8Complete suit",
@@ -104,20 +108,22 @@ public class GUISeymour extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(15) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                double coins = player.getCoins();
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                double coins = skyBlockPlayer.getCoins();
                 if (coins < elegantTuxedoPrice) {
                     return;
                 }
-                player.addAndUpdateItem(ItemType.ELEGANT_TUXEDO_CHESTPLATE);
-                player.addAndUpdateItem(ItemType.ELEGANT_TUXEDO_BOOTS);
-                player.addAndUpdateItem(ItemType.ELEGANT_TUXEDO_LEGGINGS);
-                player.playSuccessSound();
-                player.removeCoins(elegantTuxedoPrice);
+                skyBlockPlayer.addAndUpdateItem(ItemType.ELEGANT_TUXEDO_CHESTPLATE);
+                skyBlockPlayer.addAndUpdateItem(ItemType.ELEGANT_TUXEDO_BOOTS);
+                skyBlockPlayer.addAndUpdateItem(ItemType.ELEGANT_TUXEDO_LEGGINGS);
+                skyBlockPlayer.playSuccessSound();
+                skyBlockPlayer.removeCoins(elegantTuxedoPrice);
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 ItemStack.Builder builder = ItemStackCreator.getStack("§6Elegant Tuxedo", Material.LEATHER_CHESTPLATE, 1,
                         "",
                         "§8Complete suit",

--- a/type.hub/src/main/java/net/swofty/type/hub/gui/GUIShopWoolWeaverCool.java
+++ b/type.hub/src/main/java/net/swofty/type/hub/gui/GUIShopWoolWeaverCool.java
@@ -9,6 +9,7 @@ import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
 import net.swofty.type.skyblockgeneric.item.SkyBlockItem;
 import net.swofty.type.skyblockgeneric.shop.type.CoinShopPrice;
 import net.swofty.type.skyblockgeneric.user.SkyBlockPlayer;
+import net.swofty.type.generic.user.HypixelPlayer;
 
 public class GUIShopWoolWeaverCool extends SkyBlockShopGUI {
     public GUIShopWoolWeaverCool() {
@@ -19,12 +20,12 @@ public class GUIShopWoolWeaverCool extends SkyBlockShopGUI {
     public void onOpen(InventoryGUIOpenEvent e) {
         set(new GUIClickableItem(45) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
                 new GUIShopWoolWeaverCool().open(player);
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.createNamedItemStack(Material.ARROW, "§a->");
             }
         });

--- a/type.hub/src/main/java/net/swofty/type/hub/gui/GUIShopWoolWeaverVibrant.java
+++ b/type.hub/src/main/java/net/swofty/type/hub/gui/GUIShopWoolWeaverVibrant.java
@@ -9,6 +9,7 @@ import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
 import net.swofty.type.skyblockgeneric.item.SkyBlockItem;
 import net.swofty.type.skyblockgeneric.shop.type.CoinShopPrice;
 import net.swofty.type.skyblockgeneric.user.SkyBlockPlayer;
+import net.swofty.type.generic.user.HypixelPlayer;
 
 public class GUIShopWoolWeaverVibrant extends SkyBlockShopGUI {
     public GUIShopWoolWeaverVibrant() {
@@ -19,12 +20,12 @@ public class GUIShopWoolWeaverVibrant extends SkyBlockShopGUI {
     public void onOpen(InventoryGUIOpenEvent e) {
         set(new GUIClickableItem(53) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
                 new GUIShopWoolWeaverCool().open(player);
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.createNamedItemStack(Material.ARROW, "§a->");
             }
         });

--- a/type.hub/src/main/java/net/swofty/type/hub/gui/GUITiaTheFairy.java
+++ b/type.hub/src/main/java/net/swofty/type/hub/gui/GUITiaTheFairy.java
@@ -8,11 +8,13 @@ import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.swofty.type.skyblockgeneric.data.datapoints.DatapointBackpacks;
 import net.swofty.type.skyblockgeneric.data.datapoints.DatapointFairySouls;
+import net.swofty.type.skyblockgeneric.data.SkyBlockDataHandler;
 import net.swofty.type.generic.gui.inventory.ItemStackCreator;
 import net.swofty.type.generic.gui.inventory.HypixelInventoryGUI;
 import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
 import net.swofty.type.skyblockgeneric.levels.SkyBlockLevelCause;
 import net.swofty.type.skyblockgeneric.user.SkyBlockPlayer;
+import net.swofty.type.generic.user.HypixelPlayer;
 import net.swofty.type.skyblockgeneric.user.fairysouls.FairySoulExchangeLevels;
 
 import java.util.ArrayList;
@@ -34,20 +36,21 @@ public class GUITiaTheFairy extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(22) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 if (!canExchange) {
-                    player.sendMessage("§cYou don't have enough Fairy Souls!");
+                    skyBlockPlayer.sendMessage("§cYou don't have enough Fairy Souls!");
                     return;
                 }
 
                 player.closeInventory();
-                player.getFairySouls().exchange();
-                player.getSkyBlockData().get(SkyBlockDataHandler.Data.FAIRY_SOULS, DatapointFairySouls.class)
-                                .setValue(player.getFairySouls());
-                player.sendMessage("§aYou have exchanged your Fairy Souls for rewards!");
-                nextLevel.getDisplay().forEach(player::sendMessage);
+                skyBlockPlayer.getFairySouls().exchange();
+                skyBlockPlayer.getSkyBlockData().get(SkyBlockDataHandler.Data.FAIRY_SOULS, DatapointFairySouls.class)
+                                .setValue(skyBlockPlayer.getFairySouls());
+                skyBlockPlayer.sendMessage("§aYou have exchanged your Fairy Souls for rewards!");
+                nextLevel.getDisplay().forEach(skyBlockPlayer::sendMessage);
 
-                player.getSkyBlockExperience().addExperience(
+                skyBlockPlayer.getSkyBlockExperience().addExperience(
                         SkyBlockLevelCause.getFairySoulExchangeCause(nextLevel.ordinal())
                 );
 
@@ -61,7 +64,8 @@ public class GUITiaTheFairy extends HypixelInventoryGUI {
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 List<String> lore = new ArrayList<>(List.of(
                         "§7Find §dFairy Souls §7around the",
                         "§7world and bring them back to me",
@@ -98,7 +102,7 @@ public class GUITiaTheFairy extends HypixelInventoryGUI {
     }
 
     @Override
-    public void suddenlyQuit(Inventory inventory, SkyBlockPlayer player) {
+    public void suddenlyQuit(Inventory inventory, HypixelPlayer player) {
     }
 
     @Override

--- a/type.hub/src/main/java/net/swofty/type/hub/gui/elizabeth/GUIBuyBoosterCookies.java
+++ b/type.hub/src/main/java/net/swofty/type/hub/gui/elizabeth/GUIBuyBoosterCookies.java
@@ -18,6 +18,7 @@ import net.swofty.type.generic.gui.inventory.HypixelInventoryGUI;
 import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
 import net.swofty.type.generic.gui.inventory.item.GUIItem;
 import net.swofty.type.skyblockgeneric.user.SkyBlockPlayer;
+import net.swofty.type.generic.user.HypixelPlayer;
 
 import java.util.ArrayList;
 import java.util.Objects;
@@ -53,13 +54,13 @@ public class GUIBuyBoosterCookies extends HypixelInventoryGUI {
             GUIAccountAndProfileUpgrades.ShopCategorys shopCategorys = allShopCategorys[index];
             set(new GUIClickableItem(slot) {
                 @Override
-                public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+                public void run(InventoryPreClickEvent e, HypixelPlayer player) {
                     if (slot != 3) {
                         shopCategorys.gui.open(player);
                     }
                 }
                 @Override
-                public ItemStack.Builder getItem(SkyBlockPlayer player) {
+                public ItemStack.Builder getItem(HypixelPlayer player) {
                     ItemStack.Builder itemStack = shopCategorys.stack;
                     ArrayList<String> lore = new ArrayList<>(itemStack.build().get(ItemComponent.LORE).stream().map(StringUtility::getTextFromComponent).toList());
                     if (slot != 3) {
@@ -85,7 +86,7 @@ public class GUIBuyBoosterCookies extends HypixelInventoryGUI {
 
         for (int slot : categoriesItemsSlots) {
             set(new GUIItem(slot) {
-                public ItemStack.Builder getItem(SkyBlockPlayer player) {
+                public ItemStack.Builder getItem(HypixelPlayer player) {
                     if (slot != 12) {
                         return ItemStackCreator.getStack("§8▲ §7Categories", Material.GRAY_STAINED_GLASS_PANE, 1, "§8▼ §7Items");
                     } else {
@@ -97,18 +98,20 @@ public class GUIBuyBoosterCookies extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(29) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                if (player.getGems() >= cookieCost) {
-                    player.addAndUpdateItem(ItemType.BOOSTER_COOKIE);
-                    player.removeGems(cookieCost);
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                if (skyBlockPlayer.getGems() >= cookieCost) {
+                    skyBlockPlayer.addAndUpdateItem(ItemType.BOOSTER_COOKIE);
+                    skyBlockPlayer.removeGems(cookieCost);
                     new GUIBuyBoosterCookies().open(player);
                 } else {
-                    player.openBook(book);
+                    skyBlockPlayer.openBook(book);
                 }
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 ItemStack.Builder itemStack = ItemStackCreator.enchant(ItemStackCreator.getStack("§6Single Cookie", Material.COOKIE, 1,
                         " ",
                         "§6Booster Cookie §8x1",
@@ -160,18 +163,20 @@ public class GUIBuyBoosterCookies extends HypixelInventoryGUI {
             final int totalCookiePrice = boosterCookieAmount*cookieCost;
 
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                if (player.getGems() >= totalCookiePrice) {
-                    player.addAndUpdateItem(ItemType.BOOSTER_COOKIE, boosterCookieAmount);
-                    player.removeGems(totalCookiePrice);
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                if (skyBlockPlayer.getGems() >= totalCookiePrice) {
+                    skyBlockPlayer.addAndUpdateItem(ItemType.BOOSTER_COOKIE, boosterCookieAmount);
+                    skyBlockPlayer.removeGems(totalCookiePrice);
                     new GUIBuyBoosterCookies().open(player);
                 } else {
-                    player.openBook(book);
+                    skyBlockPlayer.openBook(book);
                 }
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 ItemStack.Builder itemStack = ItemStackCreator.enchant(ItemStackCreator.getStack("§6Half-Dozen Cookies", Material.COOKIE, 1,
                         " ",
                         "§6Booster Cookie §8x6",
@@ -223,18 +228,20 @@ public class GUIBuyBoosterCookies extends HypixelInventoryGUI {
             final int totalCookiePrice = boosterCookieAmount*cookieCost;
 
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                if (player.getGems() >= totalCookiePrice) {
-                    player.addAndUpdateItem(ItemType.BOOSTER_COOKIE, boosterCookieAmount);
-                    player.removeGems(totalCookiePrice);
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                if (skyBlockPlayer.getGems() >= totalCookiePrice) {
+                    skyBlockPlayer.addAndUpdateItem(ItemType.BOOSTER_COOKIE, boosterCookieAmount);
+                    skyBlockPlayer.removeGems(totalCookiePrice);
                     new GUIBuyBoosterCookies().open(player);
                 } else {
-                    player.openBook(book);
+                    skyBlockPlayer.openBook(book);
                 }
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 ItemStack.Builder itemStack = ItemStackCreator.enchant(ItemStackCreator.getStack("§6A Dozen Cookies", Material.COOKIE, 1,
                         " ",
                         "§6Booster Cookie §8x12",
@@ -283,19 +290,21 @@ public class GUIBuyBoosterCookies extends HypixelInventoryGUI {
         });
         set(new GUIClickableItem(49) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                player.openBook(book);
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                skyBlockPlayer.openBook(book);
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 return ItemStackCreator.enchant(ItemStackCreator.getStack("§aCommunity Shop", Material.EMERALD, 1,
                         "§8Elizabeth",
                         " ",
-                        "§7Gems: §a" + StringUtility.commaify(player.getGems()),
+                        "§7Gems: §a" + StringUtility.commaify(skyBlockPlayer.getGems()),
                         "§8Purchase on store.hypixel.net!",
                         " ",
-                        "§7Bits: §b" + StringUtility.commaify(player.getBits()),
+                        "§7Bits: §b" + StringUtility.commaify(skyBlockPlayer.getBits()),
                         "§8Earn from Booster Cookies!",
                         " ",
                         "§7Fame Rank: §e",
@@ -316,7 +325,7 @@ public class GUIBuyBoosterCookies extends HypixelInventoryGUI {
     }
 
     @Override
-    public void suddenlyQuit(Inventory inventory, SkyBlockPlayer player) {
+    public void suddenlyQuit(Inventory inventory, HypixelPlayer player) {
     }
 
     @Override

--- a/type.hub/src/main/java/net/swofty/type/hub/gui/kat/GUIConfirmKat.java
+++ b/type.hub/src/main/java/net/swofty/type/hub/gui/kat/GUIConfirmKat.java
@@ -12,6 +12,7 @@ import net.swofty.type.skyblockgeneric.item.SkyBlockItem;
 import net.swofty.type.skyblockgeneric.item.components.PetComponent;
 import net.swofty.type.skyblockgeneric.item.handlers.pet.KatUpgrade;
 import net.swofty.type.skyblockgeneric.user.SkyBlockPlayer;
+import net.swofty.type.generic.user.HypixelPlayer;
 
 public class GUIConfirmKat extends HypixelInventoryGUI {
 
@@ -28,20 +29,21 @@ public class GUIConfirmKat extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(11) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 if (pet.getComponent(PetComponent.class).getKatUpgrades().getForRarity(pet.getAttributeHandler().getRarity().upgrade()) == null) return;
                 KatUpgrade katUpgrade = pet.getComponent(PetComponent.class).getKatUpgrades().getForRarity(pet.getAttributeHandler().getRarity().upgrade());
                 int coins = katUpgrade.getCoins();
                 long time = katUpgrade.getTime();
 
                 Long timeWhenFinished = time + System.currentTimeMillis();
-                player.getKatData().setKatMap(timeWhenFinished, pet);
-                player.removeCoins(coins);
+                skyBlockPlayer.getKatData().setKatMap(timeWhenFinished, pet);
+                skyBlockPlayer.removeCoins(coins);
                 player.closeInventory();
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 if (pet.getComponent(PetComponent.class).getKatUpgrades().getForRarity(pet.getAttributeHandler().getRarity().upgrade()) == null) {
                     return ItemStackCreator.getStack("§aSomething went wrong!", Material.RED_TERRACOTTA, 1);
                 }
@@ -57,13 +59,14 @@ public class GUIConfirmKat extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(15) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 player.closeInventory();
-                player.addAndUpdateItem(pet);
+                skyBlockPlayer.addAndUpdateItem(pet);
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§cCancel", Material.RED_TERRACOTTA, 1);
             }
         });

--- a/type.island/src/main/java/net/swofty/type/island/gui/GUIGuests.java
+++ b/type.island/src/main/java/net/swofty/type/island/gui/GUIGuests.java
@@ -23,12 +23,12 @@ public class GUIGuests extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(31) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
                 new GUIJerry().open(player);
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aGo Back", Material.ARROW, 1,
                         "§7To Jerry the Assistant"
                 );
@@ -37,11 +37,11 @@ public class GUIGuests extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(10) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aVisit player islands", Material.FEATHER, 1,
                         "§7You can get Guest on other islands",
                         "§7using §a/visit <player>",
@@ -55,13 +55,14 @@ public class GUIGuests extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(12) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 player.closeInventory();
-                player.sendMessage("§eVisit our web store: §6https://store.hypixel.net");
+                skyBlockPlayer.sendMessage("§eVisit our web store: §6https://store.hypixel.net");
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aGuests limit", Material.SHORT_GRASS, 1,
                         "§7You can only host a limited",
                         "§7number of §aguests §7on your",
@@ -86,11 +87,11 @@ public class GUIGuests extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(14) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aAccess Permissions", Material.OAK_FENCE, 1,
                         "§7You may edit who is able to",
                         "§7guest on your island in your",
@@ -107,11 +108,11 @@ public class GUIGuests extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(16) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aModeration", Material.REPEATER, 1,
                         "§7Manage online guests using the",
                         "§eGuests Management §7menu.",
@@ -135,7 +136,7 @@ public class GUIGuests extends HypixelInventoryGUI {
     }
 
     @Override
-    public void suddenlyQuit(Inventory inventory, SkyBlockPlayer player) {
+    public void suddenlyQuit(Inventory inventory, HypixelPlayer player) {
     }
 
     @Override

--- a/type.island/src/main/java/net/swofty/type/island/gui/GUIGuests.java
+++ b/type.island/src/main/java/net/swofty/type/island/gui/GUIGuests.java
@@ -10,6 +10,7 @@ import net.swofty.type.generic.gui.inventory.ItemStackCreator;
 import net.swofty.type.generic.gui.inventory.HypixelInventoryGUI;
 import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
 import net.swofty.type.skyblockgeneric.user.SkyBlockPlayer;
+import net.swofty.type.generic.user.HypixelPlayer;
 
 public class GUIGuests extends HypixelInventoryGUI {
     public GUIGuests() {

--- a/type.island/src/main/java/net/swofty/type/island/gui/GUIJerry.java
+++ b/type.island/src/main/java/net/swofty/type/island/gui/GUIJerry.java
@@ -11,6 +11,7 @@ import net.swofty.type.generic.gui.inventory.ItemStackCreator;
 import net.swofty.type.generic.gui.inventory.HypixelInventoryGUI;
 import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
 import net.swofty.type.skyblockgeneric.user.SkyBlockPlayer;
+import net.swofty.type.generic.user.HypixelPlayer;
 
 public class GUIJerry extends HypixelInventoryGUI {
     public GUIJerry() {
@@ -24,12 +25,12 @@ public class GUIJerry extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(11) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
                 new GUIPatchNotes().open(player);
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aPatch Notes", Material.BOOK, 1,
                         "§7View the latest features and",
                         "§7changes to the game.",
@@ -41,12 +42,13 @@ public class GUIJerry extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(13) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                player.sendMessage("§cNo new deliveries.");
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                skyBlockPlayer.sendMessage("§cNo new deliveries.");
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aDeliveries", Material.ENDER_CHEST, 1,
                         "§7Any items that may be delivered to",
                         "§7yourself or your island will appear",
@@ -59,12 +61,12 @@ public class GUIJerry extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(15) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
                 new GUIGuests().open(player);
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aVisits and Guestings", Material.EMERALD, 1,
                         "§7Learn all about how to §a/visit",
                         "§7players across the SkyBlock universe!",
@@ -76,15 +78,16 @@ public class GUIJerry extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(35) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
                 player.closeInventory();
-                player.sendMessage("§aI have given you an egg, place this where you would like me to move to!");
+                skyBlockPlayer.sendMessage("§aI have given you an egg, place this where you would like me to move to!");
 
-                player.addAndUpdateItem(ItemType.MOVE_JERRY);
+                skyBlockPlayer.addAndUpdateItem(ItemType.MOVE_JERRY);
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.createNamedItemStack(Material.BEDROCK, "§aMove Jerry");
             }
         });
@@ -103,7 +106,7 @@ public class GUIJerry extends HypixelInventoryGUI {
     }
 
     @Override
-    public void suddenlyQuit(Inventory inventory, SkyBlockPlayer player) {
+    public void suddenlyQuit(Inventory inventory, HypixelPlayer player) {
 
     }
 

--- a/type.island/src/main/java/net/swofty/type/island/gui/GUIPatchNotes.java
+++ b/type.island/src/main/java/net/swofty/type/island/gui/GUIPatchNotes.java
@@ -12,6 +12,7 @@ import net.swofty.type.generic.gui.inventory.ItemStackCreator;
 import net.swofty.type.generic.gui.inventory.HypixelInventoryGUI;
 import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
 import net.swofty.type.skyblockgeneric.user.SkyBlockPlayer;
+import net.swofty.type.generic.user.HypixelPlayer;
 
 public class GUIPatchNotes extends HypixelInventoryGUI {
     public GUIPatchNotes() {
@@ -23,12 +24,12 @@ public class GUIPatchNotes extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(31) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
                 new GUIJerry().open(player);
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aGo Back", Material.ARROW, 1,
                         "§7To Jerry the Assistant"
                 );
@@ -37,13 +38,14 @@ public class GUIPatchNotes extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(16) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                player.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                skyBlockPlayer.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
                         .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://discord.com/channels/830345347867476000/849739331278733332/1225968992909525056")));
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aSkyBlock v1.0.2", Material.BOOK, 1,
                         "§76th April 2024",
                         "",
@@ -53,8 +55,9 @@ public class GUIPatchNotes extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(15) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                player.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                skyBlockPlayer.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
                         .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://discord.com/channels/830345347867476000/849739331278733332/1226864370122887229")));
             }
 

--- a/type.island/src/main/java/net/swofty/type/island/gui/GUIPatchNotes.java
+++ b/type.island/src/main/java/net/swofty/type/island/gui/GUIPatchNotes.java
@@ -62,7 +62,7 @@ public class GUIPatchNotes extends HypixelInventoryGUI {
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aSkyBlock v1.0.3", Material.STICK, 1,
                         "§78th April 2024",
                         "",
@@ -72,13 +72,14 @@ public class GUIPatchNotes extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(14) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                player.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                skyBlockPlayer.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
                         .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://discord.com/channels/830345347867476000/849739331278733332/1227143736669114459")));
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aSkyBlock v1.1.0", Material.BLAZE_POWDER, 1,
                         "§79th April 2024",
                         "",
@@ -88,13 +89,14 @@ public class GUIPatchNotes extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(13) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                player.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                skyBlockPlayer.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
                         .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://discord.com/channels/830345347867476000/849739331278733332/1227909009336569906")));
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aSkyBlock v1.1.1", Material.HOPPER, 1,
                         "§711th April 2024",
                         "",
@@ -104,13 +106,14 @@ public class GUIPatchNotes extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(12) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                player.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                skyBlockPlayer.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
                         .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://discord.com/channels/830345347867476000/849739331278733332/1229007700302495765")));
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aSkyBlock v1.1.3", Material.GOLD_INGOT, 1,
                         "§715th April 2024",
                         "",
@@ -120,13 +123,14 @@ public class GUIPatchNotes extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(11) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                player.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                skyBlockPlayer.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
                         .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://discord.com/channels/830345347867476000/849739331278733332/1230477957764612146")));
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aSkyBlock v1.1.4", Material.DISPENSER, 1,
                         "§718th April 2024",
                         "",
@@ -136,13 +140,14 @@ public class GUIPatchNotes extends HypixelInventoryGUI {
 
         set(new GUIClickableItem(10) {
             @Override
-            public void run(InventoryPreClickEvent e, SkyBlockPlayer player) {
-                player.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
+            public void run(InventoryPreClickEvent e, HypixelPlayer player) {
+                SkyBlockPlayer skyBlockPlayer = (SkyBlockPlayer) player;
+                skyBlockPlayer.sendMessage(Component.text("§fView Patch Notes §e§lCLICK HERE")
                         .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.OPEN_URL, "https://discord.com/channels/830345347867476000/849739331278733332/1231214757114282065")));
             }
 
             @Override
-            public ItemStack.Builder getItem(SkyBlockPlayer player) {
+            public ItemStack.Builder getItem(HypixelPlayer player) {
                 return ItemStackCreator.getStack("§aSkyBlock v1.1.5", Material.DIAMOND, 1,
                         "§720th April 2024",
                         "",
@@ -161,7 +166,7 @@ public class GUIPatchNotes extends HypixelInventoryGUI {
     }
 
     @Override
-    public void suddenlyQuit(Inventory inventory, SkyBlockPlayer player) {
+    public void suddenlyQuit(Inventory inventory, HypixelPlayer player) {
     }
 
     @Override


### PR DESCRIPTION
Refactor `GUIClickableItem` implementations to use `HypixelPlayer` in method signatures and cast to `SkyBlockPlayer` for SkyBlock-specific logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-52503430-a0d4-43eb-aa10-77121d788302">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-52503430-a0d4-43eb-aa10-77121d788302">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

