### PR TITLE
fix: update command package path in SkyBlockGenericLoader

### DIFF
--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/SkyBlockGenericLoader.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/SkyBlockGenericLoader.java
@@ -158,7 +158,7 @@ public record SkyBlockGenericLoader(HypixelTypeLoader typeLoader) {
         /**
          * Register commands
          */
-        loopThroughPackage("net.swofty.type.skyblockgeneric.command.commands", HypixelCommand.class).forEach(command -> {
+        loopThroughPackage("net.swofty.type.skyblockgeneric.commands", HypixelCommand.class).forEach(command -> {
             try {
                 MinecraftServer.getCommandManager().register(command.getCommand());
             } catch (Exception e) {


### PR DESCRIPTION
The package name after the migration was wrong, so no SkyBlock commands were loaded