### PR TITLE
GUIMaterial & little Stats Menus improvements 

### DIFF
--- a/type.generic/src/main/java/net/swofty/type/generic/gui/inventory/item/GUIMaterial.java
+++ b/type.generic/src/main/java/net/swofty/type/generic/gui/inventory/item/GUIMaterial.java
@@ -1,0 +1,18 @@
+package net.swofty.type.generic.gui.inventory.item;
+
+import net.minestom.server.item.Material;
+import org.jetbrains.annotations.Nullable;
+
+public record GUIMaterial(Material material, @Nullable String texture) {
+    public GUIMaterial(Material material) {
+        this(material, null);
+    }
+
+    public GUIMaterial(@Nullable String texture) {
+        this(Material.PLAYER_HEAD, texture);
+    }
+
+    public boolean hasTexture() {
+        return texture != null && !texture.isEmpty();
+    }
+}

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/chest/DoubleChest.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/chest/DoubleChest.java
@@ -6,6 +6,7 @@ import net.minestom.server.instance.Instance;
 import net.minestom.server.inventory.InventoryType;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.tag.Tag;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,7 +15,7 @@ import java.util.List;
 
 public class DoubleChest implements Chest {
 
-    private static final Tag<List<ItemStack>> ITEMS_TAG = Tag.ItemStack("configuration/skyblock/items").list();
+    private static final Tag<@NotNull List<ItemStack>> ITEMS_TAG = Tag.ItemStack("configuration/skyblock/items").list();
     private final Instance instance;
     private final Point leftPosition;
     private final Point rightPosition;

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/chest/SingleChest.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/chest/SingleChest.java
@@ -5,13 +5,14 @@ import net.minestom.server.instance.Instance;
 import net.minestom.server.inventory.InventoryType;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.tag.Tag;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.List;
 
 public class SingleChest implements Chest {
 
-    private static final Tag<List<ItemStack>> ITEMS_TAG = Tag.ItemStack("configuration/skyblock/items").list();
+    private static final Tag<@NotNull List<ItemStack>> ITEMS_TAG = Tag.ItemStack("configuration/skyblock/items").list();
 
     private final Instance instance;
     private final Point position;

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/BestiaryMob.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/BestiaryMob.java
@@ -1,7 +1,7 @@
 package net.swofty.type.skyblockgeneric.entity.mob;
 
 import net.minestom.server.entity.EntityType;
-import net.minestom.server.item.Material;
+import net.swofty.type.generic.gui.inventory.item.GUIMaterial;
 
 public abstract class BestiaryMob extends SkyBlockMob {
     public BestiaryMob(EntityType entityType) {
@@ -11,6 +11,5 @@ public abstract class BestiaryMob extends SkyBlockMob {
     public abstract int getMaxBestiaryTier();
     public abstract int getBestiaryBracket();
     public abstract String getMobID();
-    public abstract Material getDisplayItem();
-    public abstract String getTexture();
+    public abstract GUIMaterial getGuiMaterial();
 }

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/mobs/hub/MobGraveyardZombie.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/mobs/hub/MobGraveyardZombie.java
@@ -10,11 +10,13 @@ import net.minestom.server.utils.time.TimeUnit;
 import net.swofty.commons.item.ItemType;
 import net.swofty.commons.statistics.ItemStatistic;
 import net.swofty.commons.statistics.ItemStatistics;
+import net.swofty.type.generic.gui.inventory.item.GUIMaterial;
 import net.swofty.type.skyblockgeneric.entity.mob.BestiaryMob;
 import net.swofty.type.skyblockgeneric.entity.mob.ai.ClosestEntityRegionTarget;
 import net.swofty.type.skyblockgeneric.entity.mob.ai.MeleeAttackWithinRegionGoal;
 import net.swofty.type.skyblockgeneric.entity.mob.ai.RandomRegionStrollGoal;
 import net.swofty.type.skyblockgeneric.entity.mob.impl.RegionPopulator;
+import net.swofty.type.skyblockgeneric.gui.inventories.sbmenu.bestiary.GUIBestiaryMob;
 import net.swofty.type.skyblockgeneric.loottable.OtherLoot;
 import net.swofty.type.skyblockgeneric.loottable.SkyBlockLootTable;
 import net.swofty.type.skyblockgeneric.region.RegionType;
@@ -120,13 +122,8 @@ public class MobGraveyardZombie extends BestiaryMob implements RegionPopulator {
     }
 
     @Override
-    public Material getDisplayItem() {
-        return Material.ZOMBIE_HEAD;
-    }
-
-    @Override
-    public String getTexture() {
-        return "";
+    public GUIMaterial getGuiMaterial() {
+        return new GUIMaterial(Material.ZOMBIE_HEAD);
     }
 
     @Override

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/mobs/hub/MobGraveyardZombieVillager.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/mobs/hub/MobGraveyardZombieVillager.java
@@ -10,6 +10,7 @@ import net.minestom.server.utils.time.TimeUnit;
 import net.swofty.commons.item.ItemType;
 import net.swofty.commons.statistics.ItemStatistic;
 import net.swofty.commons.statistics.ItemStatistics;
+import net.swofty.type.generic.gui.inventory.item.GUIMaterial;
 import net.swofty.type.skyblockgeneric.entity.mob.BestiaryMob;
 import net.swofty.type.skyblockgeneric.entity.mob.ai.ClosestEntityRegionTarget;
 import net.swofty.type.skyblockgeneric.entity.mob.ai.MeleeAttackWithinRegionGoal;
@@ -122,13 +123,8 @@ public class MobGraveyardZombieVillager extends BestiaryMob implements RegionPop
     }
 
     @Override
-    public Material getDisplayItem() {
-        return Material.PLAYER_HEAD;
-    }
-
-    @Override
-    public String getTexture() {
-        return "69198f410a10f99314aa0fbe9a3db10697bbc1c011f019507d96673c64217f5a";
+    public GUIMaterial getGuiMaterial() {
+        return new GUIMaterial("69198f410a10f99314aa0fbe9a3db10697bbc1c011f019507d96673c64217f5a");
     }
 
     @Override

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/mobs/hub/MobRuinsOldWolf.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/mobs/hub/MobRuinsOldWolf.java
@@ -10,6 +10,7 @@ import net.minestom.server.utils.time.TimeUnit;
 import net.swofty.commons.item.ItemType;
 import net.swofty.commons.statistics.ItemStatistic;
 import net.swofty.commons.statistics.ItemStatistics;
+import net.swofty.type.generic.gui.inventory.item.GUIMaterial;
 import net.swofty.type.skyblockgeneric.entity.mob.BestiaryMob;
 import net.swofty.type.skyblockgeneric.entity.mob.ai.ClosestEntityRegionTarget;
 import net.swofty.type.skyblockgeneric.entity.mob.ai.MeleeAttackWithinRegionGoal;
@@ -128,12 +129,7 @@ public class MobRuinsOldWolf extends BestiaryMob implements RegionPopulator {
     }
 
     @Override
-    public Material getDisplayItem() {
-        return Material.PLAYER_HEAD;
-    }
-
-    @Override
-    public String getTexture() {
-        return "d359537c15534f61c1cd886bc118774ed22280e7cdab6613870160aad4ca39";
+    public GUIMaterial getGuiMaterial() {
+        return new GUIMaterial("d359537c15534f61c1cd886bc118774ed22280e7cdab6613870160aad4ca39");
     }
 }

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/mobs/hub/MobRuinsWolf.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/mobs/hub/MobRuinsWolf.java
@@ -10,6 +10,7 @@ import net.minestom.server.utils.time.TimeUnit;
 import net.swofty.commons.item.ItemType;
 import net.swofty.commons.statistics.ItemStatistic;
 import net.swofty.commons.statistics.ItemStatistics;
+import net.swofty.type.generic.gui.inventory.item.GUIMaterial;
 import net.swofty.type.skyblockgeneric.entity.mob.BestiaryMob;
 import net.swofty.type.skyblockgeneric.entity.mob.ai.ClosestEntityRegionTarget;
 import net.swofty.type.skyblockgeneric.entity.mob.ai.MeleeAttackWithinRegionGoal;
@@ -129,12 +130,7 @@ public class MobRuinsWolf extends BestiaryMob implements RegionPopulator {
     }
 
     @Override
-    public Material getDisplayItem() {
-        return Material.PLAYER_HEAD;
-    }
-
-    @Override
-    public String getTexture() {
-        return "f4cb7a6bf6c32c49f2589147e6f0f888e9e35875dd1ea2a8af379ca710589e6b";
+    public GUIMaterial getGuiMaterial() {
+        return new GUIMaterial("f4cb7a6bf6c32c49f2589147e6f0f888e9e35875dd1ea2a8af379ca710589e6b");
     }
 }

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/mobs/island/MobZombie_1.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/mobs/island/MobZombie_1.java
@@ -10,6 +10,7 @@ import net.minestom.server.utils.time.TimeUnit;
 import net.swofty.commons.item.ItemType;
 import net.swofty.commons.statistics.ItemStatistic;
 import net.swofty.commons.statistics.ItemStatistics;
+import net.swofty.type.generic.gui.inventory.item.GUIMaterial;
 import net.swofty.type.skyblockgeneric.entity.mob.BestiaryMob;
 import net.swofty.type.skyblockgeneric.entity.mob.ai.MeleeAttackWithinRegionGoal;
 import net.swofty.type.skyblockgeneric.entity.mob.ai.RandomRegionStrollGoal;
@@ -114,13 +115,8 @@ public class MobZombie_1 extends BestiaryMob implements RegionPopulator {
     }
 
     @Override
-    public Material getDisplayItem() {
-        return Material.ZOMBIE_HEAD;
-    }
-
-    @Override
-    public String getTexture() {
-        return "";
+    public GUIMaterial getGuiMaterial() {
+        return new GUIMaterial(Material.ZOMBIE_HEAD);
     }
 
     @Override

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/event/actions/custom/levels/ActionChangeHypixelXP.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/event/actions/custom/levels/ActionChangeHypixelXP.java
@@ -14,7 +14,6 @@ import java.util.List;
 
 public class ActionChangeHypixelXP implements HypixelEventClass {
 
-
     @HypixelEvent(node = EventNodes.CUSTOM, requireDataLoaded = true)
     public void run(SkyBlockXPModificationEvent event) {
         if (event.getNewXP() <= event.getOldXP()) return;

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/bestiary/BestiaryCategory.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/bestiary/BestiaryCategory.java
@@ -2,6 +2,7 @@ package net.swofty.type.skyblockgeneric.gui.inventories.sbmenu.bestiary;
 
 import lombok.Getter;
 import net.minestom.server.item.Material;
+import net.swofty.type.generic.gui.inventory.item.GUIMaterial;
 import net.swofty.type.skyblockgeneric.entity.mob.BestiaryMob;
 import net.swofty.type.skyblockgeneric.entity.mob.mobs.hub.MobGraveyardZombie;
 import net.swofty.type.skyblockgeneric.entity.mob.mobs.hub.MobGraveyardZombieVillager;
@@ -17,39 +18,37 @@ public enum BestiaryCategory {
 
     @Getter
     public enum PRIVATE_ISLAND implements BestiaryEntry {
-        ZOMBIE("§aZombie", "Brains.", Material.ZOMBIE_HEAD, "", List.of(new MobZombie_1(), new MobZombie_2())),
+        ZOMBIE("§aZombie", "Brains.", new GUIMaterial(Material.ZOMBIE_HEAD), List.of(new MobZombie_1(), new MobZombie_2())),
         ;
 
-        private final String name, description, texture;
-        private final Material material;
+        private final String name, description;
+        private final GUIMaterial guiMaterial;
         private final List<BestiaryMob> mobs;
 
-        PRIVATE_ISLAND(String name, String description, Material material, String texture, List<BestiaryMob> mobs) {
+        PRIVATE_ISLAND(String name, String description, GUIMaterial guiMaterial, List<BestiaryMob> mobs) {
             this.name = name;
             this.description = description;
-            this.material = material;
-            this.texture = texture;
+            this.guiMaterial = guiMaterial;
             this.mobs = mobs;
         }
     }
 
     @Getter
     public enum HUB implements BestiaryEntry {
-        GRAVEYARD_ZOMBIE("§aGraveyard Zombie", "Brains.", Material.ZOMBIE_HEAD, "", List.of(new MobGraveyardZombie())),
-        OLD_WOLF("§aOld Wolf", "Wolves older than the island itself.", Material.PLAYER_HEAD, "d359537c15534f61c1cd886bc118774ed22280e7cdab6613870160aad4ca39", List.of(new MobRuinsOldWolf())),
-        WOLF("§aWolf", "Roaming the remains of a Castle far from its best days.", Material.PLAYER_HEAD, "f4cb7a6bf6c32c49f2589147e6f0f888e9e35875dd1ea2a8af379ca710589e6b", List.of(new MobRuinsWolf())),
-        ZOMBIE_VILLAGER("§aZombie Villager", "The real enemy isn't the dead - it's the living.", Material.PLAYER_HEAD, "69198f410a10f99314aa0fbe9a3db10697bbc1c011f019507d96673c64217f5a", List.of(new MobGraveyardZombieVillager())),
+        GRAVEYARD_ZOMBIE("§aGraveyard Zombie", "Brains.", new GUIMaterial(Material.ZOMBIE_HEAD), List.of(new MobGraveyardZombie())),
+        OLD_WOLF("§aOld Wolf", "Wolves older than the island itself.", new GUIMaterial("d359537c15534f61c1cd886bc118774ed22280e7cdab6613870160aad4ca39"), List.of(new MobRuinsOldWolf())),
+        WOLF("§aWolf", "Roaming the remains of a Castle far from its best days.", new GUIMaterial("f4cb7a6bf6c32c49f2589147e6f0f888e9e35875dd1ea2a8af379ca710589e6b"), List.of(new MobRuinsWolf())),
+        ZOMBIE_VILLAGER("§aZombie Villager", "The real enemy isn't the dead - it's the living.", new GUIMaterial("69198f410a10f99314aa0fbe9a3db10697bbc1c011f019507d96673c64217f5a"), List.of(new MobGraveyardZombieVillager())),
         ;
 
-        private final String name, description, texture;
-        private final Material material;
+        private final String name, description;
+        private final GUIMaterial guiMaterial;
         private final List<BestiaryMob> mobs;
 
-        HUB(String name, String description, Material material, String texture, List<BestiaryMob> mobs) {
+        HUB(String name, String description, GUIMaterial guiMaterial, List<BestiaryMob> mobs) {
             this.name = name;
             this.description = description;
-            this.material = material;
-            this.texture = texture;
+            this.guiMaterial = guiMaterial;
             this.mobs = mobs;
         }
     }

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/bestiary/BestiaryEntry.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/bestiary/BestiaryEntry.java
@@ -1,6 +1,7 @@
 package net.swofty.type.skyblockgeneric.gui.inventories.sbmenu.bestiary;
 
 import net.minestom.server.item.Material;
+import net.swofty.type.generic.gui.inventory.item.GUIMaterial;
 import net.swofty.type.skyblockgeneric.entity.mob.BestiaryMob;
 
 import java.util.List;
@@ -8,8 +9,7 @@ import java.util.List;
 public interface BestiaryEntry {
     String getName();
     String getDescription();
-    Material getMaterial();
-    String getTexture();
+    GUIMaterial getGuiMaterial();
     List<BestiaryMob> getMobs();
 }
 

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/bestiary/GUIBestiary.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/bestiary/GUIBestiary.java
@@ -11,6 +11,7 @@ import net.swofty.type.generic.gui.inventory.HypixelInventoryGUI;
 import net.swofty.type.generic.gui.inventory.ItemStackCreator;
 import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
 import net.swofty.type.generic.gui.inventory.item.GUIItem;
+import net.swofty.type.generic.gui.inventory.item.GUIMaterial;
 import net.swofty.type.generic.user.HypixelPlayer;
 import net.swofty.type.skyblockgeneric.gui.inventories.sbmenu.skills.GUISkillCategory;
 import net.swofty.type.skyblockgeneric.skill.SkillCategories;
@@ -31,35 +32,33 @@ public class GUIBestiary extends HypixelInventoryGUI {
 
     @Getter
     private enum BestiaryRegions {
-        YOUR_ISLAND("§aYour Island", Material.PLAYER_HEAD, "c9c8881e42915a9d29bb61a16fb26d059913204d265df5b439b3d792acd56", new GUIBestiaryIsland(BestiaryCategories.YOUR_ISLAND), "§7View all of the mobs that you've", "§7found and killed on §aYour Island§7."),
-        HUB("§aHub", Material.PLAYER_HEAD, "d7cc6687423d0570d556ac53e0676cb563bbdd9717cd8269bdebed6f6d4e7bf8", new GUIBestiaryIsland(BestiaryCategories.HUB), "§7View all of the mobs that you've", "§7found and killed in the §aHub§7."),
-        THE_FARMING_ISLANDS("§aThe Farming Islands", Material.PLAYER_HEAD, "4d3a6bd98ac1833c664c4909ff8d2dc62ce887bdcf3cc5b3848651ae5af6b", null, "§7View all of the mobs that you've", "§7found and killed in §aThe Farming", "§aIslands§7."),
-        GARDEN("§bGarden", Material.PLAYER_HEAD, "f4880d2c1e7b86e87522e20882656f45bafd42f94932b2c5e0d6ecaa490cb4c", null, "§7View all of the §6Pests §7that you've", "§7killed on the §bGarden§7."),
-        SPIDERS_DEN("§cSpider's Den", Material.PLAYER_HEAD, "c754318a3376f470e481dfcd6c83a59aa690ad4b4dd7577fdad1c2ef08d8aee6", null, "§7View all of the mobs that you've", "§7found and killed in the §cSpider's Den§7."),
-        THE_END("§dThe End", Material.PLAYER_HEAD, "7840b87d52271d2a755dedc82877e0ed3df67dcc42ea479ec146176b02779a5", null, "§7View all of the mobs that you've", "§7found and killed in §dThe End§7."),
-        CRIMSON_ISLE("§cCrimson Isle", Material.PLAYER_HEAD, "c3687e25c632bce8aa61e0d64c24e694c3eea629ea944f4cf30dcfb4fbce071", null, "§7View all of the mobs that you've", "§7found and killed in the §cCrimson Isle§7."),
-        DEEP_CAVERNS("§bDeep Caverns", Material.PLAYER_HEAD, "569a1f114151b4521373f34bc14c2963a5011cdc25a6554c48c708cd96ebfc", null, "§7View all of the mobs that you've", "§7found and killed in the §bDeep Caverns§7."),
-        DWARVEN_MINES("§2Dwarven Mines", Material.PLAYER_HEAD, "6b20b23c1aa2be0270f016b4c90d6ee6b8330a17cfef87869d6ad60b2ffbf3b5", null, "§7View all of the mobs that you've", "§7found and killed in the §2Dwarven Mines§7."),
-        CRYSTAL_HALLOWS("§5Crystal Hallows", Material.PLAYER_HEAD, "21dbe30b027acbceb612563bd877cd7ebb719ea6ed1399027dcee58bb9049d4a", null, "§7View all of the mobs that you've", "§7found and killed in the §5Crystal", "§5Hollows§7."),
-        THE_PARK("§3The Park", Material.PLAYER_HEAD, "a221f813dacee0fef8c59f76894dbb26415478d9ddfc44c2e708a6d3b7549b", null, "§7View all of the mobs that you've", "§7found and killed in §3The Park§7."),
-        GALATEA("§2Galatea", Material.PLAYER_HEAD, "9336d7cc95cbf6689f5e8c954294ec8d1efc494a4031325bb427bc81d56a484d", null, "§7View all of the mobs that you've", "§7found and killed in §2Galatea§7."),
-        SPOOKY_FESTIVAL("§6Spooky Festival", Material.JACK_O_LANTERN, "", null, "§7View all of the mobs that you've", "§7found and killed during the §6Spooky", "§6Festival§7."),
-        CATACOMBS("§cCatacombs", Material.PLAYER_HEAD, "964e1c3e315c8d8fffc37985b6681c5bd16a6f97ffd07199e8a05efbef103793", null, "§7View all of the mobs that you've", "§7found and killed in §cThe Catacombs§7."),
-        FISHING("§3Fishing", Material.FISHING_ROD, "", null, "§7View all of the §3Sea Creatures §7that", "§7you've killed while fishing."),
-        MYTHOLOGICAL_CREATURES("§bMythological Creatures", Material.PLAYER_HEAD, "83cc1cf672a4b2540be346ead79ac2d9ed19d95b6075bf95be0b6d0da61377be", null, "§7View all of the §bMythological", "§bCreatures §7that you've killed."),
-        JERRY("§6Jerry", Material.PLAYER_HEAD, "45f729736996a38e186fe9fe7f5a04b387ed03f3871ecc82fa78d8a2bdd31109", null, "§7View all of the mobs that you've", "§7found and killed while fighting §6Jerry§7."),
-        KUUDRA("§cKuudra", Material.PLAYER_HEAD, "5051c83d9ebf69013f1ec8c9efc979ec2d925a921cc877ff64abe09aadd2f6cc", null, "§7View all of the mobs that you've", "§7found and killed while fighting §cKuudra§7."),
+        YOUR_ISLAND("§aYour Island", new GUIMaterial("c9c8881e42915a9d29bb61a16fb26d059913204d265df5b439b3d792acd56"), new GUIBestiaryIsland(BestiaryCategories.YOUR_ISLAND), "§7View all of the mobs that you've", "§7found and killed on §aYour Island§7."),
+        HUB("§aHub", new GUIMaterial("d7cc6687423d0570d556ac53e0676cb563bbdd9717cd8269bdebed6f6d4e7bf8"), new GUIBestiaryIsland(BestiaryCategories.HUB), "§7View all of the mobs that you've", "§7found and killed in the §aHub§7."),
+        THE_FARMING_ISLANDS("§aThe Farming Islands", new GUIMaterial("4d3a6bd98ac1833c664c4909ff8d2dc62ce887bdcf3cc5b3848651ae5af6b"), null, "§7View all of the mobs that you've", "§7found and killed in §aThe Farming", "§aIslands§7."),
+        GARDEN("§bGarden", new GUIMaterial("f4880d2c1e7b86e87522e20882656f45bafd42f94932b2c5e0d6ecaa490cb4c"), null, "§7View all of the §6Pests §7that you've", "§7killed on the §bGarden§7."),
+        SPIDERS_DEN("§cSpider's Den", new GUIMaterial("c754318a3376f470e481dfcd6c83a59aa690ad4b4dd7577fdad1c2ef08d8aee6"), null, "§7View all of the mobs that you've", "§7found and killed in the §cSpider's Den§7."),
+        THE_END("§dThe End", new GUIMaterial("7840b87d52271d2a755dedc82877e0ed3df67dcc42ea479ec146176b02779a5"), null, "§7View all of the mobs that you've", "§7found and killed in §dThe End§7."),
+        CRIMSON_ISLE("§cCrimson Isle", new GUIMaterial("c3687e25c632bce8aa61e0d64c24e694c3eea629ea944f4cf30dcfb4fbce071"), null, "§7View all of the mobs that you've", "§7found and killed in the §cCrimson Isle§7."),
+        DEEP_CAVERNS("§bDeep Caverns", new GUIMaterial("569a1f114151b4521373f34bc14c2963a5011cdc25a6554c48c708cd96ebfc"), null, "§7View all of the mobs that you've", "§7found and killed in the §bDeep Caverns§7."),
+        DWARVEN_MINES("§2Dwarven Mines", new GUIMaterial("6b20b23c1aa2be0270f016b4c90d6ee6b8330a17cfef87869d6ad60b2ffbf3b5"), null, "§7View all of the mobs that you've", "§7found and killed in the §2Dwarven Mines§7."),
+        CRYSTAL_HALLOWS("§5Crystal Hallows", new GUIMaterial("21dbe30b027acbceb612563bd877cd7ebb719ea6ed1399027dcee58bb9049d4a"), null, "§7View all of the mobs that you've", "§7found and killed in the §5Crystal", "§5Hollows§7."),
+        THE_PARK("§3The Park", new GUIMaterial("a221f813dacee0fef8c59f76894dbb26415478d9ddfc44c2e708a6d3b7549b"), null, "§7View all of the mobs that you've", "§7found and killed in §3The Park§7."),
+        GALATEA("§2Galatea", new GUIMaterial("9336d7cc95cbf6689f5e8c954294ec8d1efc494a4031325bb427bc81d56a484d"), null, "§7View all of the mobs that you've", "§7found and killed in §2Galatea§7."),
+        SPOOKY_FESTIVAL("§6Spooky Festival", new GUIMaterial(Material.JACK_O_LANTERN), null, "§7View all of the mobs that you've", "§7found and killed during the §6Spooky", "§6Festival§7."),
+        CATACOMBS("§cCatacombs", new GUIMaterial("964e1c3e315c8d8fffc37985b6681c5bd16a6f97ffd07199e8a05efbef103793"), null, "§7View all of the mobs that you've", "§7found and killed in §cThe Catacombs§7."),
+        FISHING("§3Fishing", new GUIMaterial(Material.FISHING_ROD), null, "§7View all of the §3Sea Creatures §7that", "§7you've killed while fishing."),
+        MYTHOLOGICAL_CREATURES("§bMythological Creatures", new GUIMaterial("83cc1cf672a4b2540be346ead79ac2d9ed19d95b6075bf95be0b6d0da61377be"), null, "§7View all of the §bMythological", "§bCreatures §7that you've killed."),
+        JERRY("§6Jerry", new GUIMaterial("45f729736996a38e186fe9fe7f5a04b387ed03f3871ecc82fa78d8a2bdd31109"), null, "§7View all of the mobs that you've", "§7found and killed while fighting §6Jerry§7."),
+        KUUDRA("§cKuudra", new GUIMaterial("5051c83d9ebf69013f1ec8c9efc979ec2d925a921cc877ff64abe09aadd2f6cc"), null, "§7View all of the mobs that you've", "§7found and killed while fighting §cKuudra§7."),
         ;
         private final String regionName;
-        private final Material material;
-        private final String texture;
+        private final GUIMaterial guiMaterial;
         private final HypixelInventoryGUI gui;
         private final String[] lore;
 
-        BestiaryRegions(String regionName, Material material, String texture, HypixelInventoryGUI gui, String... lore) {
+        BestiaryRegions(String regionName, GUIMaterial guiMaterial, HypixelInventoryGUI gui, String... lore) {
             this.regionName = regionName;
-            this.material = material;
-            this.texture = texture;
+            this.guiMaterial = guiMaterial;
             this.gui = gui;
             this.lore = lore;
         }
@@ -98,10 +97,11 @@ public class GUIBestiary extends HypixelInventoryGUI {
 
                 public ItemStack.Builder getItem(HypixelPlayer p) {
                     SkyBlockPlayer player = (SkyBlockPlayer) p;
-                    if (bestiaryRegion.material == Material.PLAYER_HEAD) {
-                        return ItemStackCreator.getStackHead(bestiaryRegion.regionName, bestiaryRegion.texture, 1, bestiaryRegion.lore);
+                    GUIMaterial guiMaterial = bestiaryRegion.guiMaterial;
+                    if (guiMaterial.hasTexture()) {
+                        return ItemStackCreator.getStackHead(bestiaryRegion.regionName, guiMaterial.texture(), 1, bestiaryRegion.lore);
                     } else {
-                        return ItemStackCreator.getStack(bestiaryRegion.regionName, bestiaryRegion.material, 1, bestiaryRegion.lore);
+                        return ItemStackCreator.getStack(bestiaryRegion.regionName, guiMaterial.material(), 1, bestiaryRegion.lore);
                     }
                 }
             });

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/bestiary/GUIBestiaryIsland.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/bestiary/GUIBestiaryIsland.java
@@ -11,6 +11,7 @@ import net.swofty.type.generic.gui.inventory.HypixelInventoryGUI;
 import net.swofty.type.generic.gui.inventory.ItemStackCreator;
 import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
 import net.swofty.type.generic.gui.inventory.item.GUIItem;
+import net.swofty.type.generic.gui.inventory.item.GUIMaterial;
 import net.swofty.type.generic.user.HypixelPlayer;
 import net.swofty.type.skyblockgeneric.bestiary.BestiaryData;
 import net.swofty.type.skyblockgeneric.entity.mob.BestiaryMob;
@@ -124,17 +125,18 @@ public class GUIBestiaryIsland extends HypixelInventoryGUI {
                     public ItemStack.Builder getItem(HypixelPlayer p) {
                         SkyBlockPlayer player = (SkyBlockPlayer) p;
                         ArrayList<String> lore = new ArrayList<>();
+                        GUIMaterial guiMaterial = bestiaryEntry.getGuiMaterial();
 
                         player.getBestiaryData().getMobDisplay(lore, kills, mob, bestiaryEntry);
 
                         lore.add("§eClick to view!");
 
-                        if (bestiaryEntry.getMaterial() == Material.PLAYER_HEAD) {
+                        if (guiMaterial.hasTexture()) {
                             return ItemStackCreator.getStackHead("§a" + bestiaryEntry.getName() + " " + StringUtility.getAsRomanNumeral(tier),
-                                    bestiaryEntry.getTexture(), 1, lore);
+                                    guiMaterial.texture(), 1, lore);
                         } else {
                             return ItemStackCreator.getStack("§a" + bestiaryEntry.getName() + " " + StringUtility.getAsRomanNumeral(tier),
-                                    bestiaryEntry.getMaterial(), 1, lore);
+                                    guiMaterial.material(), 1, lore);
                         }
                     }
                 });

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/bestiary/GUIBestiaryMob.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/bestiary/GUIBestiaryMob.java
@@ -12,6 +12,7 @@ import net.swofty.type.generic.gui.inventory.HypixelInventoryGUI;
 import net.swofty.type.generic.gui.inventory.ItemStackCreator;
 import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
 import net.swofty.type.generic.gui.inventory.item.GUIItem;
+import net.swofty.type.generic.gui.inventory.item.GUIMaterial;
 import net.swofty.type.generic.user.HypixelPlayer;
 import net.swofty.type.skyblockgeneric.bestiary.BestiaryData;
 import net.swofty.type.skyblockgeneric.entity.mob.BestiaryMob;
@@ -66,17 +67,18 @@ public class GUIBestiaryMob extends HypixelInventoryGUI {
                 SkyBlockPlayer player = (SkyBlockPlayer) p;
                 ArrayList<String> lore = new ArrayList<>();
                 BestiaryMob mob = bestiaryEntry.getMobs().getFirst();
+                GUIMaterial guiMaterial = bestiaryEntry.getGuiMaterial();
                 int kills = ((SkyBlockPlayer) getPlayer()).getBestiaryData().getAmount(bestiaryEntry.getMobs());
                 int tier = bestiaryData.getCurrentBestiaryTier(mob, kills);
 
                 player.getBestiaryData().getMobDisplay(lore, kills, mob, bestiaryEntry);
 
-                if (bestiaryEntry.getMaterial() == Material.PLAYER_HEAD) {
+                if (guiMaterial.hasTexture()) {
                     return ItemStackCreator.getStackHead("§a" + bestiaryEntry.getName() + " " + StringUtility.getAsRomanNumeral(tier),
-                            bestiaryEntry.getTexture(), 1, lore);
+                            guiMaterial.texture(), 1, lore);
                 } else {
                     return ItemStackCreator.getStack("§a" + bestiaryEntry.getName() + " " + StringUtility.getAsRomanNumeral(tier),
-                            bestiaryEntry.getMaterial(), 1, lore);
+                            guiMaterial.material(), 1, lore);
                 }
             }
         });
@@ -88,6 +90,7 @@ public class GUIBestiaryMob extends HypixelInventoryGUI {
 
         for (int i = 0; i < bestiaryMobs.size() && i < chosenSlots.length; i++) {
             BestiaryMob mob = bestiaryMobs.get(i);
+            GUIMaterial guiMaterial = mob.getGuiMaterial();
             int slot = chosenSlots[i];
 
             set(new GUIItem(slot) {
@@ -161,10 +164,10 @@ public class GUIBestiaryMob extends HypixelInventoryGUI {
 
                     lore.removeLast();
 
-                    if (mob.getDisplayItem() == Material.PLAYER_HEAD) {
-                        return ItemStackCreator.getStackHead("§8[§7Lv" + mob.getLevel() + "§8] §f" + mob.getDisplayName(), mob.getTexture(), 1, lore);
+                    if (guiMaterial.hasTexture()) {
+                        return ItemStackCreator.getStackHead("§8[§7Lv" + mob.getLevel() + "§8] §f" + mob.getDisplayName(), guiMaterial.texture(), 1, lore);
                     } else {
-                        return ItemStackCreator.getStack("§8[§7Lv" + mob.getLevel() + "§8] §f" + mob.getDisplayName(), bestiaryEntry.getMaterial(), 1, lore);
+                        return ItemStackCreator.getStack("§8[§7Lv" + mob.getLevel() + "§8] §f" + mob.getDisplayName(), guiMaterial.material(), 1, lore);
                     }
                 }
             });

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/levels/emblem/GUIEmblems.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/levels/emblem/GUIEmblems.java
@@ -7,6 +7,7 @@ import net.minestom.server.item.Material;
 import net.swofty.type.generic.gui.inventory.HypixelInventoryGUI;
 import net.swofty.type.generic.gui.inventory.ItemStackCreator;
 import net.swofty.type.generic.gui.inventory.item.GUIClickableItem;
+import net.swofty.type.generic.gui.inventory.item.GUIMaterial;
 import net.swofty.type.generic.user.HypixelPlayer;
 import net.swofty.type.skyblockgeneric.gui.inventories.sbmenu.levels.GUISkyBlockLevels;
 import net.swofty.type.skyblockgeneric.levels.SkyBlockEmblems;
@@ -42,7 +43,7 @@ public class GUIEmblems extends HypixelInventoryGUI {
                 public ItemStack.Builder getItem(HypixelPlayer p) {
                     SkyBlockPlayer player = (SkyBlockPlayer) p;
                     String displayName = emblem.toString();
-                    Material material = emblem.getDisplayMaterial();
+                    GUIMaterial guiMaterial = emblem.getGuiMaterial();
                     ArrayList<String> description = new ArrayList<>(emblem.getDescription());
 
                     ArrayList<String> lore = new ArrayList<>(Arrays.asList(
@@ -53,7 +54,11 @@ public class GUIEmblems extends HypixelInventoryGUI {
                     lore.add(" ");
                     lore.add("§eClick to view!");
 
-                    return ItemStackCreator.getStack("§a" + displayName, material, 1, lore);
+                    if (guiMaterial.hasTexture()) {
+                        return ItemStackCreator.getStackHead("§a" + displayName, guiMaterial.texture(), 1, lore);
+                    } else {
+                        return ItemStackCreator.getStack("§a" + displayName, guiMaterial.material(), 1, lore);
+                    }
                 }
             });
         });

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/stats/GUICombatStats.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/stats/GUICombatStats.java
@@ -247,26 +247,22 @@ public class GUICombatStats extends HypixelInventoryGUI {
                 SkyBlockPlayer player = (SkyBlockPlayer) p;
                 ItemStatistic statistic = ItemStatistic.BONUS_ATTACK_SPEED;
                 double value = player.getStatistics().allStatistics().getOverall(statistic);
-                List<String> lore = new ArrayList<>(
-                        value == 0D ?
-                                List.of(
-                                        "§7Attack Speed decreases the time",
-                                        "§7between hits on your opponent.",
-                                        " ",
-                                        "§7You attack at a normal rate.",
-                                        " "
-                                ) :
-                                List.of(
-                                        "§7Attack Speed decreases the time",
-                                        "§7between hits on your opponent.",
-                                        " ",
-                                        "§7Flat: " + statistic.getDisplayColor() + "+" + StringUtility.commaify(value) + statistic.getSymbol(),
-                                        "§7Stat Cap:" + statistic.getDisplayColor() + "100" + statistic.getSymbol() + " " + statistic.getDisplayName(),
-                                        " ",
-                                        "§7You now attack §a" + StringUtility.commaify(value) + "§7faster!",
-                                        " "
-                                )
-                );
+                List<String> lore = new ArrayList<>();
+
+                lore.add("§7Attack Speed decreases the time");
+                lore.add("§7between hits on your opponent.");
+                lore.add(" ");
+
+                if (value == 0D) {
+                    lore.add("§7You attack at a normal rate.");
+                    lore.add(" ");
+                } else {
+                    lore.add("§7Flat: " + statistic.getDisplayColor() + "+" + StringUtility.commaify(value) + statistic.getSymbol());
+                    lore.add("§7Stat Cap:" + statistic.getDisplayColor() + "100" + statistic.getSymbol() + " " + statistic.getDisplayName());
+                    lore.add(" ");
+                    lore.add("§7You now attack §a" + StringUtility.commaify(value) + "§7 faster!");
+                    lore.add(" ");
+                }
 
                 if (value == 0D) lore.add("§8You have none of this stat!");
                 lore.add("§eClick to view!");
@@ -349,32 +345,23 @@ public class GUICombatStats extends HypixelInventoryGUI {
                 double value = player.getStatistics().allStatistics().getOverall(statistic);
                 int extraStrikes = (int) (value / 100);
                 double chanceForOneMore = value % 100;
-                List<String> lore = new ArrayList<>(
-                        value == 0D ?
-                                List.of(
-                                        "§7Ferocity grants percent chance to",
-                                        "§7double-strike enemies.Increments of",
-                                        "§7100 increases the base number of",
-                                        "§7strikes.",
-                                        " ",
-                                        "§7Base extra strikes: " + statistic.getDisplayColor() + StringUtility.commaify(extraStrikes),
-                                        "§7Chance for 1 more: " + statistic.getDisplayColor() + StringUtility.commaify(chanceForOneMore) + "%",
-                                        " "
-                                ) :
-                                List.of(
-                                        "§7Ferocity grants percent chance to",
-                                        "§7double-strike enemies.Increments of",
-                                        "§7100 increases the base number of",
-                                        "§7strikes.",
-                                        " ",
-                                        "§7Flat: " + statistic.getDisplayColor() + "+" + StringUtility.commaify(value) + statistic.getSymbol(),
-                                        "§7Stat Cap:" + statistic.getDisplayColor() + "500" + statistic.getSymbol() + statistic.getDisplayName(),
-                                        " ",
-                                        "§7Base extra strikes: " + statistic.getDisplayColor() + StringUtility.commaify(extraStrikes),
-                                        "§7Chance for 1 more: " + statistic.getDisplayColor() + StringUtility.commaify(chanceForOneMore) + "%",
-                                        " "
-                                )
-                );
+                List<String> lore = new ArrayList<>();
+
+                lore.add("§7Ferocity grants percent chance to");
+                lore.add("§7double-strike enemies. Increments of");
+                lore.add("§7100 increases the base number of");
+                lore.add("§7strikes.");
+                lore.add(" ");
+
+                if (value != 0D) {
+                    lore.add("§7Flat: " + statistic.getDisplayColor() + "+" + StringUtility.commaify(value) + statistic.getSymbol());
+                    lore.add("§7Stat Cap:" + statistic.getDisplayColor() + "500" + statistic.getSymbol() + statistic.getDisplayName());
+                    lore.add(" ");
+                }
+
+                lore.add("§7Base extra strikes: " + statistic.getDisplayColor() + StringUtility.commaify(extraStrikes));
+                lore.add("§7Chance for 1 more: " + statistic.getDisplayColor() + StringUtility.commaify(chanceForOneMore) + "%");
+                lore.add(" ");
 
                 if (value == 0D) lore.add("§8You have none of this stat!");
                 lore.add("§eClick to view!");
@@ -437,24 +424,21 @@ public class GUICombatStats extends HypixelInventoryGUI {
                 ItemStatistic statistic = ItemStatistic.VITALITY;
                 double value = player.getStatistics().allStatistics().getOverall(statistic);
                 double bonus = value / 100D;
-                List<String> lore = new ArrayList<>(
-                        value == statistic.getBaseAdditiveValue() ?
-                                List.of(
-                                        "§7Vitality increases your incoming",
-                                        "§7healing, including health regen.",
-                                        " ",
-                                        "§8Heals you receive aren't modified.",
-                                        " "
-                                ) :
-                                List.of(
-                                        "§7Vitality increases your incoming",
-                                        "§7healing, including health regen.",
-                                        " ",
-                                        "§7All heals applied to you are multiplied by " + statistic.getDisplayColor() + StringUtility.decimalify(bonus, 2) + "x§7.",
-                                        " "
-                                )
+                List<String> lore = new ArrayList<>();
 
-                );
+                lore.add("§7Vitality increases your incoming");
+                lore.add("§7healing, including health regen.");
+                lore.add(" ");
+
+                if (value == statistic.getBaseAdditiveValue()) {
+                    lore.add("§8Heals you receive aren't modified.");
+                } else {
+                    lore.add("§7All heals applied to you are multiplied by "
+                            + statistic.getDisplayColor()
+                            + StringUtility.decimalify(bonus, 2) + "x§7.");
+                }
+
+                lore.add(" ");
 
                 if (value == 0D) lore.add("§8You have none of this stat!");
                 lore.add("§eClick to view!");
@@ -478,23 +462,20 @@ public class GUICombatStats extends HypixelInventoryGUI {
                 ItemStatistic statistic = ItemStatistic.MENDING;
                 double value = player.getStatistics().allStatistics().getOverall(statistic);
                 double bonus = value / 100D;
-                List<String> lore = new ArrayList<>(
-                        value == statistic.getBaseAdditiveValue() ?
-                                List.of(
-                                        "§7Mending increases your outgoing",
-                                        "§7healing.",
-                                        " ",
-                                        "§8Your heals aren't modified.",
-                                        " "
-                                ) :
-                                List.of(
-                                        "§7Mending increases your outgoing",
-                                        "§7healing.",
-                                        " ",
-                                        "§7All heals applied to you are multiplied by " + statistic.getDisplayColor() + StringUtility.decimalify(bonus, 2) + "x§7."
-                                )
+                List<String> lore = new ArrayList<>();
 
-                );
+                lore.add("§7Mending increases your outgoing");
+                lore.add("§7healing.");
+                lore.add(" ");
+
+                if (value == statistic.getBaseAdditiveValue()) {
+                    lore.add("§8Your heals aren't modified.");
+                    lore.add(" ");
+                } else {
+                    lore.add("§7All heals applied to you are multiplied by "
+                            + statistic.getDisplayColor()
+                            + StringUtility.decimalify(bonus, 2) + "x§7.");
+                }
 
                 if (value == 0D) lore.add("§8You have none of this stat!");
                 lore.add("§eClick to view!");
@@ -517,28 +498,22 @@ public class GUICombatStats extends HypixelInventoryGUI {
                 SkyBlockPlayer player = (SkyBlockPlayer) p;
                 ItemStatistic statistic = ItemStatistic.SWING_RANGE;
                 double value = player.getStatistics().allStatistics().getOverall(statistic);
-                List<String> lore = new ArrayList<>(
-                        value == statistic.getBaseAdditiveValue() ?
-                                List.of(
-                                        "§7Increases your melee hit range.",
-                                        " ",
-                                        "§7Flat: " + statistic.getDisplayColor() + "+" + StringUtility.decimalify(value, 2) + statistic.getSymbol(),
-                                        "§7Stat Cap: " + statistic.getDisplayColor() + "15" + statistic.getSymbol() + " " + statistic.getDisplayName(),
-                                        " ",
-                                        "§8Your swing range isn't modified.",
-                                        " "
-                                ) :
-                                List.of(
-                                        "§7Increases your melee hit range.",
-                                        " ",
-                                        "§7Flat: " + statistic.getDisplayColor() + "+" + StringUtility.decimalify(value, 2) + statistic.getSymbol(),
-                                        "§7Stat Cap: " + statistic.getDisplayColor() + "15" + statistic.getSymbol() + " " + statistic.getDisplayName(),
-                                        " ",
-                                        "§7Your swing range is increased to " + StringUtility.decimalify(value, 2) + " §7blocks.",
-                                        " "
-                                )
+                List<String> lore = new ArrayList<>();
 
-                );
+                lore.add("§7Increases your melee hit range.");
+                lore.add(" ");
+                lore.add("§7Flat: " + statistic.getDisplayColor() + "+" + StringUtility.decimalify(value, 2) + statistic.getSymbol());
+                lore.add("§7Stat Cap: " + statistic.getDisplayColor() + "15" + statistic.getSymbol() + " " + statistic.getDisplayName());
+                lore.add(" ");
+
+                if (value == statistic.getBaseAdditiveValue()) {
+                    lore.add("§8Your swing range isn't modified.");
+                } else {
+                    lore.add("§7Your swing range is increased to "
+                            + StringUtility.decimalify(value, 2) + " §7blocks.");
+                }
+
+                lore.add(" ");
 
                 if (value == 0D) lore.add("§8You have none of this stat!");
                 lore.add("§eClick to view!");

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/stats/GUIGatheringStats.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/stats/GUIGatheringStats.java
@@ -103,30 +103,21 @@ public class GUIGatheringStats extends HypixelInventoryGUI {
                 SkyBlockPlayer player = (SkyBlockPlayer) p;
                 ItemStatistic statistic = ItemStatistic.MINING_SPREAD;
                 double value = player.getStatistics().allStatistics().getOverall(statistic);
-                List<String> lore = new ArrayList<>(
-                        value == 0D ?
-                                List.of(
-                                        "§7§cDisabled by: §fPrivate Island",
-                                        " ",
-                                        "§7Mining Spread is the chance to",
-                                        "§7automatically mine adjacent blocks",
-                                        "§7Blocks, Ores, and",
-                                        "§7Dwarven Metals.",
-                                        " "
-                                ) :
-                                List.of(
-                                        "§7§cDisabled by: §fPrivate Island",
-                                        " ",
-                                        "§7Mining Spread is the chance to",
-                                        "§7automatically mine adjacent blocks",
-                                        "§7Blocks, Ores, and",
-                                        "§7Dwarven Metals.",
-                                        " ",
-                                        "§7Flat: " + statistic.getDisplayColor() + "+" + StringUtility.commaify(value) + statistic.getSymbol(),
-                                        "§7Stat Cap: " + statistic.getDisplayColor() + StringUtility.commaify(10000) + statistic.getSymbol(),
-                                        " "
-                                )
-                );
+                List<String> lore = new ArrayList<>();
+
+                lore.add("§7§cDisabled by: §fPrivate Island");
+                lore.add(" ");
+                lore.add("§7Mining Spread is the chance to");
+                lore.add("§7automatically mine adjacent blocks");
+                lore.add("§7Blocks, Ores, and");
+                lore.add("§7Dwarven Metals.");
+                lore.add(" ");
+
+                if (value != 0D) {
+                    lore.add("§7Flat: " + statistic.getDisplayColor() + "+" + StringUtility.commaify(value) + statistic.getSymbol());
+                    lore.add("§7Stat Cap: " + statistic.getDisplayColor() + StringUtility.commaify(10000) + statistic.getSymbol());
+                    lore.add(" ");
+                }
 
                 addFormateNumberLore(value, "block", statistic, lore);
 
@@ -196,10 +187,7 @@ public class GUIGatheringStats extends HypixelInventoryGUI {
                 lore.add("§eClick to view!");
                 return ItemStackCreator.getStackHead(StringUtility.getFormatedStatistic(statistic) + " §f" +
                                 StringUtility.decimalify(value, 1),
-                        new PlayerSkin(
-                                "ewogICJ0aW1lc3RhbXAiIDogMTYyNDk3OTI3NDk3OSwKICAicHJvZmlsZUlkIiA6ICJiNjM2OWQ0MzMwNTU0NGIzOWE5OTBhODYyNWY5MmEwNSIsCiAgInByb2ZpbGVOYW1lIiA6ICJCb2JpbmhvXyIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9kODg2ZTBmNDExODViMThhM2FmZDg5NDg4ZDJlZTRjYWEwNzM1MDA5MjQ3Y2NjZjAzOWNlZDZhZWQ3NTJmZjFhIgogICAgfQogIH0KfQ==",
-                                "kIeN2GgeBNMP+/2aHijXKT2nGSxi5L5fD79GQzL/Gn7fBI8HexuVG4ttz74xfuow0Aq/4C5A+f66QGHrvqNTreLn6I1NqI9cnvx0cgpBKJGum7i6u60jSyDBAoc9rjwBY40mlSjwAyC41n7/Y5/QolS2u+Ofo35vtidSIwqHha+9jCL8FlwVjKnD3nP+cXLDFXVbfCjjdIZGsWl9viup23cQGnGVNh5eWsl3r6DA+cMoU4NKebICwB6bSsOlu2wj2WzfFAhsbL9DFpVaMvH7U8Rrb9lavG97yel01h1w/uBSWF+qaMPRZtjq56IjSRprG2WVEO3SqLs2b5LJ04qbsRW4UJ9vEfwTjlh1CINFhQZ7BwqlLuNv0RgUaCq5gqr5kk0Pit8R5cbEyvAa6w6L2V0XbPi8kjTVvdiep2U7FVwNLCaxFVxEq1nSGE3mkfUbxYhp9CCEBtA9im+hlLnPFzV7e7MfW6GzBbo+o1ELwpfFHWZfwRflSmi8B56O8fsNHEm8kXmwwt5WAouSLVhmB3+qGOYDqxJf19VRHK+KRJ+0XBCt+3PCJ1Mk7vh0EqMWsWQUZlHAl08cpOUR/IIphWuuqHilL2Dy86pNnSKCKkZBE6U3EASZegdpRJjsdxyk6glw575RPnts+4qkVE9o4TbwttnK6BDzTXyeV5KIPro="
-                        ), 1, lore
+                        "d886e0f41185b18a3afd89488d2ee4caa0735009247cccf039ced6aed752ff1a", 1, lore
                 );
 
             }
@@ -233,10 +221,7 @@ public class GUIGatheringStats extends HypixelInventoryGUI {
                 lore.add("§eClick to view!");
                 return ItemStackCreator.getStackHead(StringUtility.getFormatedStatistic(statistic) + " §f" +
                                 StringUtility.decimalify(value, 1),
-                        new PlayerSkin(
-                                "ewogICJ0aW1lc3RhbXAiIDogMTcwNjczNTY3MTQ2OSwKICAicHJvZmlsZUlkIiA6ICI2NTk0YzdiMTExOWE0Njc3ODc0Y2ZmOWNlMzM3NzYxOSIsCiAgInByb2ZpbGVOYW1lIiA6ICJNYXJzaG1lbGxvMjIiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjczNTc5NTc1Y2E4OGIzYThhZmUxZWQxODkwN2IzMTI1ZmUwOTg3YjAyYTg4ZWYwZThhMDEwODdjM2QwMjRjNCIKICAgIH0KICB9Cn0=",
-                                "t/ckqd8i3jF6GLH6i7MxxNvCArtdJeTcVB+KNhGkK1saTDLXPWpRzMYD3yzsT5n2696Z3kki1V/89Acx/mP02EZvspjUj5ShDf5yKZA/rnKqkM9T6j06SVb2VOqWAV0AiOY/BiIY5iMXXP3KNO8cymZlRVMl4gN2bSt0KZ+1bjGIr6Sjd1ulTqMtCJIj9Zd3XJtWULu/XEC/oM2FJmJRFE1Uridei6VxjUhwy3KN+Sm4EqeEPX4afJk1X0cUhI/OrDuTj0vQQgFbHW8Rqr/S/Cg+AJTu6poStEnnzbQ0Vf+SpOoossIr2QJRc03K88xZBpUUDnyTqVCs5RHCAcmftGqKfq/KaCph4QHbgnbJf/iYJ2WzmIadgW/nxqnaanmhIdHhlEQV256vUl4MiFwpYSqlHJ7HgiaJ94fcnNaHa8U9K6sN5LHb10bZL4skf2Js/yobfX5xzxg9LIjDgt3digu61ouQJQIFLz9WkwRSwOALlWDar8MyPJJOSyX36AH3FpLAx88Ut4IlN6W4WQOdqQnTPtQHtO7/jRRmvYBz5VGGjdFB32zWNMaK1nLnC8Eflt3PzX9BY9QLaZp+qzYV6Mq4B2bovI5QNooitUAqSacFfhQWIs0aaE46V9g30lU4pKmMbuUEFh6D4wmPXIFDsqIzCT6A8b8A+EiCaOGXz3Q="
-                        ), 1, lore
+                        "b73579575ca88b3a8afe1ed18907b3125fe0987b02a88ef0e8a01087c3d024c4", 1, lore
                 );
             }
         });
@@ -270,10 +255,7 @@ public class GUIGatheringStats extends HypixelInventoryGUI {
                 lore.add("§eClick to view!");
                 return ItemStackCreator.getStackHead(StringUtility.getFormatedStatistic(statistic) + " §f" +
                                 StringUtility.decimalify(value, 1),
-                        new PlayerSkin(
-                                "ewogICJ0aW1lc3RhbXAiIDogMTcwNjczNTY3MTQ2OSwKICAicHJvZmlsZUlkIiA6ICI2NTk0YzdiMTExOWE0Njc3ODc0Y2ZmOWNlMzM3NzYxOSIsCiAgInByb2ZpbGVOYW1lIiA6ICJNYXJzaG1lbGxvMjIiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjczNTc5NTc1Y2E4OGIzYThhZmUxZWQxODkwN2IzMTI1ZmUwOTg3YjAyYTg4ZWYwZThhMDEwODdjM2QwMjRjNCIKICAgIH0KICB9Cn0=",
-                                "t/ckqd8i3jF6GLH6i7MxxNvCArtdJeTcVB+KNhGkK1saTDLXPWpRzMYD3yzsT5n2696Z3kki1V/89Acx/mP02EZvspjUj5ShDf5yKZA/rnKqkM9T6j06SVb2VOqWAV0AiOY/BiIY5iMXXP3KNO8cymZlRVMl4gN2bSt0KZ+1bjGIr6Sjd1ulTqMtCJIj9Zd3XJtWULu/XEC/oM2FJmJRFE1Uridei6VxjUhwy3KN+Sm4EqeEPX4afJk1X0cUhI/OrDuTj0vQQgFbHW8Rqr/S/Cg+AJTu6poStEnnzbQ0Vf+SpOoossIr2QJRc03K88xZBpUUDnyTqVCs5RHCAcmftGqKfq/KaCph4QHbgnbJf/iYJ2WzmIadgW/nxqnaanmhIdHhlEQV256vUl4MiFwpYSqlHJ7HgiaJ94fcnNaHa8U9K6sN5LHb10bZL4skf2Js/yobfX5xzxg9LIjDgt3digu61ouQJQIFLz9WkwRSwOALlWDar8MyPJJOSyX36AH3FpLAx88Ut4IlN6W4WQOdqQnTPtQHtO7/jRRmvYBz5VGGjdFB32zWNMaK1nLnC8Eflt3PzX9BY9QLaZp+qzYV6Mq4B2bovI5QNooitUAqSacFfhQWIs0aaE46V9g30lU4pKmMbuUEFh6D4wmPXIFDsqIzCT6A8b8A+EiCaOGXz3Q="
-                        ), 1, lore
+                        "b73579575ca88b3a8afe1ed18907b3125fe0987b02a88ef0e8a01087c3d024c4", 1, lore
                 );
             }
         });
@@ -381,10 +363,7 @@ public class GUIGatheringStats extends HypixelInventoryGUI {
                 lore.add("§eClick to view!");
                 return ItemStackCreator.getStackHead(StringUtility.getFormatedStatistic(statistic) + " §f" +
                                 StringUtility.decimalify(value, 1),
-                        new PlayerSkin(
-                                "ewogICJ0aW1lc3RhbXAiIDogMTcwNjczNTY3MTQ2OSwKICAicHJvZmlsZUlkIiA6ICI2NTk0YzdiMTExOWE0Njc3ODc0Y2ZmOWNlMzM3NzYxOSIsCiAgInByb2ZpbGVOYW1lIiA6ICJNYXJzaG1lbGxvMjIiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjczNTc5NTc1Y2E4OGIzYThhZmUxZWQxODkwN2IzMTI1ZmUwOTg3YjAyYTg4ZWYwZThhMDEwODdjM2QwMjRjNCIKICAgIH0KICB9Cn0=",
-                                "t/ckqd8i3jF6GLH6i7MxxNvCArtdJeTcVB+KNhGkK1saTDLXPWpRzMYD3yzsT5n2696Z3kki1V/89Acx/mP02EZvspjUj5ShDf5yKZA/rnKqkM9T6j06SVb2VOqWAV0AiOY/BiIY5iMXXP3KNO8cymZlRVMl4gN2bSt0KZ+1bjGIr6Sjd1ulTqMtCJIj9Zd3XJtWULu/XEC/oM2FJmJRFE1Uridei6VxjUhwy3KN+Sm4EqeEPX4afJk1X0cUhI/OrDuTj0vQQgFbHW8Rqr/S/Cg+AJTu6poStEnnzbQ0Vf+SpOoossIr2QJRc03K88xZBpUUDnyTqVCs5RHCAcmftGqKfq/KaCph4QHbgnbJf/iYJ2WzmIadgW/nxqnaanmhIdHhlEQV256vUl4MiFwpYSqlHJ7HgiaJ94fcnNaHa8U9K6sN5LHb10bZL4skf2Js/yobfX5xzxg9LIjDgt3digu61ouQJQIFLz9WkwRSwOALlWDar8MyPJJOSyX36AH3FpLAx88Ut4IlN6W4WQOdqQnTPtQHtO7/jRRmvYBz5VGGjdFB32zWNMaK1nLnC8Eflt3PzX9BY9QLaZp+qzYV6Mq4B2bovI5QNooitUAqSacFfhQWIs0aaE46V9g30lU4pKmMbuUEFh6D4wmPXIFDsqIzCT6A8b8A+EiCaOGXz3Q="
-                        ), 1, lore
+                        "b73579575ca88b3a8afe1ed18907b3125fe0987b02a88ef0e8a01087c3d024c4", 1, lore
                 );
             }
         });
@@ -416,10 +395,7 @@ public class GUIGatheringStats extends HypixelInventoryGUI {
                 lore.add("§eClick to view!");
                 return ItemStackCreator.getStackHead(StringUtility.getFormatedStatistic(statistic) + " §f" +
                                 StringUtility.decimalify(value, 1),
-                        new PlayerSkin(
-                                "ewogICJ0aW1lc3RhbXAiIDogMTcyMDAyMjQwNDU0MiwKICAicHJvZmlsZUlkIiA6ICIxOWY1YzkwMWEzMjQ0YzVmYTM4NThjZGVhNDk5ZWMwYSIsCiAgInByb2ZpbGVOYW1lIiA6ICJzb2RpdW16aXAiLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNGU0NGUyYThkZmY5MGY1YjAwNWU3NmU2ZjVkYjdjMTJhZTU5Y2JiYzU2ZDhiYzgwNTBmM2UzZGJmMGMzYjczNCIsCiAgICAgICJtZXRhZGF0YSIgOiB7CiAgICAgICAgIm1vZGVsIiA6ICJzbGltIgogICAgICB9CiAgICB9CiAgfQp9",
-                                "gFg1kS04ic8Xf7iSlyW+5ekjBvUXzNPPEX9oHNQHe4WHqGobbYGdyOtl2KIzoKgnWzxJEnNYK4uLMjfVgdQwVCvm+qGtJeyJA9cNGqnyEeeKWstsnHBpQzUNtIxbMbXlgVjKTXY0NtpML6YZt9uc4JR5t4YidjB+KgC9k0Uh8Ew+oRbNcdZAKj2EOmeKBGhPtFz9tzl/xXgzKGy2SJ6LBm7rZXRLig0D/4fCs210deKxL4ztE6SpqhmmRex6U4WC+fq9U50cF5EyiYceQRGx6Dpj0W7yHh72yMoZcVNRZimUzcm/qcv/4h1Ar8mjZgJ+OWpE3JvhvDXTyFXOJLhDTmgQZRbjyG0HyuircfmVT+9TIT5iximWrr6SgldASFkJWnjGasywJ0eCHofeRJXRTD0eTkYvLWmETkxAyYu1z5EcSc3aAgJFaEo4pVBmC+q295WZ3cckCLmJcwuFNMq3pa9tUJWT/mOJuDIVRjMwItYSFHZQeAyaTG3OMXwkifhXMXs+LxbPWgtpdBO8T1SAKakpfelIAOZn/tV6Z3VnKFkaVRljuLE1TgziZ9SrA6Ru30nC3wka49aeEnA2C9jg4Fxx6xPz9WyyrdXPwuRxqESKgdM4OLwLmvfzQsosnL2rpshWzoxYqsc0ZRSy9DkxI+hmhVDcszU0+LJVk1sb++U="
-                        ), 1, lore
+                        "4e44e2a8dff90f5b005e76e6f5db7c12ae59cbbc56d8bc8050f3e3dbf0c3b734", 1, lore
                 );
             }
         });
@@ -451,10 +427,7 @@ public class GUIGatheringStats extends HypixelInventoryGUI {
                 lore.add("§eClick to view!");
                 return ItemStackCreator.getStackHead(StringUtility.getFormatedStatistic(statistic) + " §f" +
                                 StringUtility.decimalify(value, 1),
-                        new PlayerSkin(
-                                "ewogICJ0aW1lc3RhbXAiIDogMTY2NjUzNzY0NzA3MiwKICAicHJvZmlsZUlkIiA6ICIxZjEyNTNhYTVkYTQ0ZjU5YWU1YWI1NmFhZjRlNTYxNyIsCiAgInByb2ZpbGVOYW1lIiA6ICJOb3RNaUt5IiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzIyMGVlNzc0MWZmMWI5NThkYmI5ZmE3Y2RkYWQ5YzNjY2U5MzM3M2Y0NzBmOWI4MzRkYTAyZGE2N2M4MjAyYTQiCiAgICB9CiAgfQp9",
-                                "iMl8/xdyf13hH5HwEDmGK9Hmc9ZcDzA5ZjwpQy6/6N6hFMaAdqigfQo+umG5DVYM3tfElNsaElGG7ufb0BZRR692K5A7vDAJ7tv9P/+98d/thubdpOrR2V//5BWtmGbEQGmPpcdml05Z0jAElQ1WoC14+yybO0qGIS5k8Qvbly1KsBRbuyp3S6etuD15JTOjzAzi+/NP+7ao+4lKh4lefksNFbVGs03wwZIJAR5pPM46xFIBAEUa78MZCBb/8DSxIK0UBYYLb0PQp+gHwOu2mGM1NLNXaVdfTWI1a9AmgdGNB1ahbVIxP0J4JoGVAtPhRKvUfx2VBQliQnQMlmSNkqYstFNxyqO+efrR8LZQeiDWQVSs7pytjzGHaz1VKuRmEb5w5vVsHBpDwHZS1OrK1si3u5SWuV2WnjhOOV6YAfuJK02+0ID0S+r01hPuLs31RyuTExda7qdXZLgMUaj6URZpGFW+oum4+x/1fDq4typw3LXv2MIeA7lxM2MyHmNS6XCuVBcNdtBkLt9H2795TT4DWi5sMHLK8x39e4KIrK2wyaHAx+svQv5IwCh9puKenMZKtjqmziJtIhXtKp/zse6ZOiqMagokedBH2wv33RvfFrBpAEJVQfuounrU9Uvv2HFtX1o4h3d/1/iLae7l/wotkX7zeO1UQe4P6RvjeTY="
-                        ), 1, lore
+                        "220ee7741ff1b958dbb9fa7cddad9c3cce93373f470f9b834da02da67c8202a4", 1, lore
                 );
             }
         });

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/stats/GUIMiscStats.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/stats/GUIMiscStats.java
@@ -98,22 +98,17 @@ public class GUIMiscStats extends HypixelInventoryGUI {
                 SkyBlockPlayer player = (SkyBlockPlayer) p;
                 ItemStatistic statistic = ItemStatistic.MAGIC_FIND;
                 double value = player.getStatistics().allStatistics().getOverall(statistic);
-                List<String> lore = new ArrayList<>(
-                        value == 0D ?
-                                List.of(
-                                        "§7Magic Find increases how many rare",
-                                        "§7items you find.",
-                                        " "
-                                ) :
-                                List.of(
-                                        "§7Magic Find increases how many rare",
-                                        "§7items you find.",
-                                        " ",
-                                        "§7Flat: " + statistic.getDisplayColor() + "+" + StringUtility.commaify(value) + statistic.getSymbol(),
-                                        "§7Stat Cap: " + statistic.getDisplayColor() + 900 + statistic.getSymbol() + " " + statistic.getDisplayName(),
-                                        " "
-                                )
-                );
+                List<String> lore = new ArrayList<>();
+
+                lore.add("§7Magic Find increases how many rare");
+                lore.add("§7items you find.");
+                lore.add(" ");
+
+                if (value != 0D) {
+                    lore.add("§7Flat: " + statistic.getDisplayColor() + "+" + StringUtility.commaify(value) + statistic.getSymbol());
+                    lore.add("§7Stat Cap: " + statistic.getDisplayColor() + 900 + statistic.getSymbol() + " " + statistic.getDisplayName());
+                    lore.add(" ");
+                }
 
                 if (value == 0D) lore.add("§8You have none of this stat!");
                 lore.add("§eClick to view!");
@@ -147,10 +142,7 @@ public class GUIMiscStats extends HypixelInventoryGUI {
                 lore.add("§eClick to view!");
                 return ItemStackCreator.getStackHead(StringUtility.getFormatedStatistic(statistic) + " §f" +
                                 StringUtility.decimalify(value, 1),
-                        new PlayerSkin(
-                                "ewogICJ0aW1lc3RhbXAiIDogMTcyMDAyMjMyOTU2MSwKICAicHJvZmlsZUlkIiA6ICJjYmYxNGIxMGJhNWU0NzgwYjIyNmFiNmQzOTUxODk4YiIsCiAgInByb2ZpbGVOYW1lIiA6ICJFZ2d5QnV0dG9uMjQxMSIsCiAgInNpZ25hdHVyZVJlcXVpcmVkIiA6IHRydWUsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9iYzc4MzE0MjU1ZDg4NjRhNzUzZmU5NTYyMjU2NDA0NmYwZGVlMmE4MmM2ZTRlMmU3ZjQ1MmZjYjk1YWYzMThjIgogICAgfQogIH0KfQ==",
-                                "H9MjwLvSOb7JcSEZB78wegmQU1m9Fl6IOTXBC9Anm6Nbb7o8/8u/xkRWviUlI+pJyUzCEFL6bZG7qFNBXvO7SVvJMweu4stwg26FOKcDxcUkwNsPztxPmE/xeXuFZzER+mUmXK2QJCMk3oVVWvMGF68/MpLuHjTB2iu6HB5CACBya1+0QKf6oSdfncezgwsfE29U76W9gx0Nb3OCZfS4+XobfPg6Gv/u2FUIaxj3ETa2kRJ6oncqr1M7vvdRHOS84Iw1RI6TODYxcIgiWyQ6CUKWv5w9jh87hAnn3psLcyWBazAJFsdp1wekqrXaG56xCrwTNKpdLcaCNQ3gt92bo0F26UeJZt1f6h2cR5GHz5r+h8Ji8IMAL80C49JYitQZH+nfr9sMX2KxsIneYBfpNYY5Im+7bymtquu02irqrL2Bjgunat7dBYvHo0tWEWGPpspMtOpiDma1s5PfCaAsu0C55jtpKtoKVww/NV3HtHCMqcIPMI3I1VkdsO3ktWJdeOsKjmjgTuRpaD301UjvDSL33TlTz7XOtMWKkc0+UJqYA42PTd1aOyK4R/ZV6IcCGAPzXyg3zaMpXNOfJyyt0ADWRyWzKFPIkB8Rekqlv2egOYk90PryzsdTUzkAb0GHNhOYthj3kFwkFGDWGC51UNfd7iKTbpoReXW5ya5lWaE="
-                        ), 1, lore
+                        "bc78314255d8864a753fe95622564046f0dee2a82c6e4e2e7f452fcb95af318c", 1, lore
                 );
             }
         });

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/stats/GUIWisdomStats.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/gui/inventories/sbmenu/stats/GUIWisdomStats.java
@@ -78,23 +78,20 @@ public class GUIWisdomStats extends HypixelInventoryGUI {
                     ItemStatistic statistic = entry.getValue();
                     double value = player.getStatistics().allStatistics().getOverall(statistic);
                     double multiplier = 1D + value / 100D;
-                    List<String> lore = new ArrayList<>(
-                            value == 0D ?
-                                    List.of(
-                                            "§7" + statistic.getDisplayName() + "increases how much",
-                                            "§7" + statistic.getDisplayName().split(" ")[0] + "Skill XP that you gain.",
-                                            " ",
-                                            "§8You aren't learning any faster, yet!",
-                                            " "
-                                    ) :
-                                    List.of(
-                                            "§7" + statistic.getDisplayName() + "increases how much",
-                                            "§7" + statistic.getDisplayName().split(" ")[0] + "Skill XP that you gain.",
-                                            " ",
-                                            "§7XP Multiplier: " + statistic.getDisplayColor() + StringUtility.decimalify(multiplier, 2) + "x",
-                                            " "
-                                    )
-                    );
+                    List<String> lore = new ArrayList<>();
+
+                    lore.add("§7" + statistic.getDisplayName() + " increases how much");
+                    lore.add("§7" + statistic.getDisplayName().split(" ")[0] + " Skill XP that you gain.");
+                    lore.add(" ");
+
+                    if (value == 0D) {
+                        lore.add("§8You aren't learning any faster, yet!");
+                    } else {
+                        lore.add("§7XP Multiplier: " + statistic.getDisplayColor()
+                                + StringUtility.decimalify(multiplier, 2) + "x");
+                    }
+
+                    lore.add(" ");
 
                     if (value == 0D) lore.add("§8You have none of this stat!");
                     lore.add("§eClick to view!");

--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/levels/SkyBlockEmblems.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/levels/SkyBlockEmblems.java
@@ -3,6 +3,7 @@ package net.swofty.type.skyblockgeneric.levels;
 import lombok.Getter;
 import net.minestom.server.item.Material;
 import net.swofty.commons.StringUtility;
+import net.swofty.type.generic.gui.inventory.item.GUIMaterial;
 import net.swofty.type.skyblockgeneric.levels.abstr.SkyBlockLevelCauseAbstr;
 import net.swofty.type.skyblockgeneric.levels.causes.LevelCause;
 import net.swofty.type.skyblockgeneric.skill.SkillCategories;
@@ -14,7 +15,7 @@ import java.util.List;
 
 @Getter
 public enum SkyBlockEmblems {
-    SKILLS(Material.DIAMOND_SWORD, List.of("§7These symbols are related to", "§7levelling up your Skills!"), List.of(
+    SKILLS(new GUIMaterial(Material.DIAMOND_SWORD), List.of("§7These symbols are related to", "§7levelling up your Skills!"), List.of(
             new SkyBlockEmblem("Mining Pickaxe", Material.STONE_PICKAXE, "§7⸕",
                     SkyBlockLevelCause.getSkillCause(SkillCategories.MINING, 50)),
             new SkyBlockEmblem("Mining Master", Material.GOLDEN_PICKAXE, "§6⸕",
@@ -34,11 +35,11 @@ public enum SkyBlockEmblems {
             new SkyBlockEmblem("Enchanting Pencil", Material.ENCHANTING_TABLE, "§7✎",
                     SkyBlockLevelCause.getSkillCause(SkillCategories.ENCHANTING, 50)),
             new SkyBlockEmblem("Enchanting Master", Material.ENCHANTING_TABLE, "§6✎",
-                    SkyBlockLevelCause.getSkillCause(SkillCategories.ENCHANTING, 60))
+                    SkyBlockLevelCause.getSkillCause(SkillCategories.ENCHANTING, 60)),
             //new SkyBlockEmblem("Alchemy Brew", Material.BREWING_STAND, "§7☕",
             //        SkyBlockLevelCause.getSkillCause(SkillCategories.ALCHEMY, 50)),
-            //new SkyBlockEmblem("Carpentry House", Material.CRAFTING_TABLE, "§7☖",
-            //        SkyBlockLevelCause.getSkillCause(SkillCategories.CARPENTRY, 50)),
+            new SkyBlockEmblem("Carpentry House", Material.CRAFTING_TABLE, "§7☖",
+                    SkyBlockLevelCause.getSkillCause(SkillCategories.CARPENTRY, 50))
             //new SkyBlockEmblem("Taming Clover", Material.WOLF_SPAWN_EGG, "§7♣",
             //        SkyBlockLevelCause.getSkillCause(SkillCategories.TAMING, 50)),
             //new SkyBlockEmblem("Taming Master", Material.WOLF_SPAWN_EGG, "§6♣",
@@ -48,7 +49,7 @@ public enum SkyBlockEmblems {
             //new SkyBlockEmblem("Social Master", Material.EMERALD, "§6℻",
             //        SkyBlockLevelCause.getSkillCause(SkillCategories.SOCIAL, 25)) //Skills not there rn, would throw an error
     )),
-    LEVELING(Material.SKELETON_SKULL, List.of("§7These symbols are unlocked by", "§7leveling up your SkyBlock Level."), List.of(
+    LEVELING(new GUIMaterial("3255327dd8e90afad681a19231665bea2bd06065a09d77ac1408837f9e0b242"), List.of("§7These symbols are unlocked by", "§7leveling up your SkyBlock Level."), List.of(
             new SkyBlockEmblem("Diamond", Material.NAME_TAG, "§7◆",
                     SkyBlockLevelCause.getLevelCause(10)),
             new SkyBlockEmblem("Spade", Material.NAME_TAG, "§7♠",
@@ -94,12 +95,12 @@ public enum SkyBlockEmblems {
     )),
     ;
 
-    private final Material displayMaterial;
+    private final GUIMaterial guiMaterial;
     private final List<String> description;
     private final List<SkyBlockEmblem> emblems;
 
-    SkyBlockEmblems(Material displayMaterial, List<String> description, List<SkyBlockEmblem> emblems) {
-        this.displayMaterial = displayMaterial;
+    SkyBlockEmblems(GUIMaterial guiMaterial, List<String> description, List<SkyBlockEmblem> emblems) {
+        this.guiMaterial = guiMaterial;
         this.description = description;
         this.emblems = emblems;
     }


### PR DESCRIPTION
GUIMaterial removes the need of two varibles in enums (Material and Head texture) and combines them in one. Now we only need to specify either a material or a texture.