### PR TITLE
fix: island data not saved when leaving

### DIFF
--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/event/actions/player/data/ActionPlayerSkyBlockDataSave.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/event/actions/player/data/ActionPlayerSkyBlockDataSave.java
@@ -44,6 +44,9 @@ public class ActionPlayerSkyBlockDataSave implements HypixelEventClass {
             ProfilesDatabase.collection.insertOne(newDoc);
         }
 
+        if(player.getSkyBlockIsland() != null && HypixelConst.getTypeLoader().getType() == ServerType.SKYBLOCK_ISLAND)
+            player.getSkyBlockIsland().runVacantCheck();
+
         // Evict from SkyBlock cache
         SkyBlockDataHandler.skyBlockCache.remove(playerUuid);
 


### PR DESCRIPTION
https://github.com/Swofty-Developments/HypixelSkyBlock/blob/4c9b8f5251e60a86f7e5ef166aab27eb31cfb153/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/user/SkyBlockIsland.java#L175 is only being called from one place, that is `runVacantCheck()` which is only called from the vacant loop which runs every 4 tick. When a player leaves they aren't loaded anymore, so their data isn't saved. This fixes it, by adding vacant check to the `ActionPlayerSkyBlockDataSave` event listener.