### PR TITLE
feat(bedwars): show username to self

### DIFF
--- a/type.bedwarsgame/src/main/java/net/swofty/type/bedwarsgame/events/ActionPlayerChat.java
+++ b/type.bedwarsgame/src/main/java/net/swofty/type/bedwarsgame/events/ActionPlayerChat.java
@@ -6,6 +6,7 @@ import net.swofty.commons.bedwars.BedwarsLevelColor;
 import net.swofty.commons.bedwars.BedwarsLevelUtil;
 import net.swofty.type.bedwarsgame.TypeBedWarsGameLoader;
 import net.swofty.type.bedwarsgame.game.Game;
+import net.swofty.type.bedwarsgame.game.GameStatus;
 import net.swofty.type.bedwarsgame.user.BedWarsPlayer;
 import net.swofty.type.generic.data.datapoints.DatapointChatType;
 import net.swofty.type.generic.data.datapoints.DatapointLeaderboardLong;
@@ -52,6 +53,15 @@ public class ActionPlayerChat implements HypixelEventClass {
 			}
 
 			PartyManager.sendChat(player, message);
+			return;
+		}
+
+		if (game.getGameStatus() == GameStatus.WAITING) {
+			String textColor = rank.equals(Rank.DEFAULT) ? "§7" : "§f";
+
+			game.getPlayers().forEach(onlinePlayer -> {
+				onlinePlayer.sendMessage(rank.getPrefix() + player.getUsername() + textColor + ": " + finalMessage);
+			});
 			return;
 		}
 

--- a/type.bedwarsgame/src/main/java/net/swofty/type/bedwarsgame/game/Game.java
+++ b/type.bedwarsgame/src/main/java/net/swofty/type/bedwarsgame/game/Game.java
@@ -108,8 +108,10 @@ public final class Game {
 		String randomLetters = UUID.randomUUID().toString().replaceAll("-", "")
 				.substring(0, new Random().nextInt(10) + 4);
 		for (BedWarsPlayer p : players) {
-			p.sendMessage("§k" + randomLetters + " §ehas joined (§b" + players.size() + "§e/§b" + maxPlayers + "§e)");
+			String name = p == player ? player.getUsername() : randomLetters;
+			p.sendMessage("§k" + name + " §ehas joined (§b" + players.size() + "§e/§b" + maxPlayers + "§e)");
 		}
+		player.setDisplayName(Component.text(randomLetters));
 
 		if (hasMinimumPlayersForStart() && !countdown.isActive()) {
 			countdown.startCountdown();


### PR DESCRIPTION
This pull request updates the chat and join message handling in the BedWars game, particularly during the waiting phase before a game starts. The changes improve how player messages and join notifications are displayed to enhance the lobby experience and maintain anonymity before the game begins.

**Lobby chat and join message improvements:**

* Players in the waiting lobby now have their chat messages formatted with their rank prefix and appropriate text color, and messages are broadcast to all lobby players.
* When a player joins during the waiting phase, their join message uses a random string as their display name for other players, and their own display name is set to this random string, preserving anonymity before the game starts.

**Code maintenance:**

* Imported the `GameStatus` enum in `ActionPlayerChat.java` to support the new lobby chat logic.


## ^^ clicked something accidently and github generated this