### PR TITLE
fix: NPC Ryan remove item typo

### DIFF
--- a/type.thepark/src/main/java/net/swofty/type/thepark/npcs/NPCRyan.java
+++ b/type.thepark/src/main/java/net/swofty/type/thepark/npcs/NPCRyan.java
@@ -125,7 +125,7 @@ public class NPCRyan extends HypixelNPC {
 		}
 
 		if (data.isCurrentlyActive(MissionGiveRyanDarkOakLogs.class)) {
-			if (!player.removeItemFromPlayer(ItemType.DARK_OAK_LOG, 512)) {
+			if (!player.removeItemFromPlayer(ItemType.DARK_OAK_LOG, 256)) {
 				sendNPCMessage(player, "Grab me §a256 Dark Oak Logs §fand I'll make you a badge! You don't have enough yet!");
 				return;
 			}


### PR DESCRIPTION
Ryan want to remove 512 instead 256 logs and u cannot complete mission