### PR TITLE
fix: kill name display entity

### DIFF
--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/SkyBlockMob.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/entity/mob/SkyBlockMob.java
@@ -203,6 +203,7 @@ public abstract class SkyBlockMob extends EntityCreature {
     public void kill() {
         super.kill();
         mobs.remove(this);
+        nameDisplayEntity.kill();
 
         if (!(getLastDamageSource().getAttacker() instanceof SkyBlockPlayer player)) return;
 


### PR DESCRIPTION
Ensure nameDisplayEntity is killed when mob is removed.