### PR TITLE
potentially faster release workflow & tui fixes (oops)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,6 @@ on:
 permissions:
   contents: write
 
-# Only one release run may publish at a time. The release action deletes and
-# recreates the "latest" tag/release on every push, so concurrent runs race and
-# fail mid-upload with "Not Found". Queue runs and let the newest commit win.
 concurrency:
   group: add-to-github-releases
   cancel-in-progress: true
@@ -19,27 +16,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5.1.0
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Build with Gradle
+        run: ./gradlew --parallel --build-cache shadowJar
 
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version-file: setup/go.mod
-          check-latest: true
-
-      - name: Grant Gradlew Permissions
-        run: chmod +x gradlew
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-      - name: Build with Gradle
-        run: ./gradlew shadowJar
+          check-latest: false
+          cache-dependency-path: |
+            setup/go.mod
+            setup/go.sum
 
       - name: Test setup TUI
         run: go test ./...
@@ -58,16 +56,6 @@ jobs:
               rm dist/skyblock-installer
             done
           done
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
 
       - name: Add Jar to GitHub releases
         uses: marvinpinto/action-automatic-releases@latest

--- a/setup/internal/installer/assets.go
+++ b/setup/internal/installer/assets.go
@@ -1,0 +1,120 @@
+package installer
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func DownloadLimboAssets(ctx context.Context, installDir string) error {
+	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, LimboAssetsURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("download returned %s", resp.Status)
+	}
+
+	tmp, err := os.CreateTemp("", "skyblock-limbo-assets-*.zip")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	return extractZip(tmpPath, filepath.Join(installDir, "configuration"))
+}
+
+func extractZip(zipPath, dst string) error {
+	reader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	cleanDst, err := filepath.Abs(dst)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(cleanDst, 0o755); err != nil {
+		return err
+	}
+
+	for _, file := range reader.File {
+		target, err := safeZipTarget(cleanDst, file.Name)
+		if err != nil {
+			return err
+		}
+		if file.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, file.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := extractZipFile(file, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func safeZipTarget(dst, name string) (string, error) {
+	cleanName := filepath.Clean(strings.ReplaceAll(name, "\\", "/"))
+	if cleanName == "." || strings.HasPrefix(cleanName, "../") || filepath.IsAbs(cleanName) {
+		return "", fmt.Errorf("unsafe zip entry path: %s", name)
+	}
+
+	target := filepath.Join(dst, cleanName)
+	cleanTarget, err := filepath.Abs(target)
+	if err != nil {
+		return "", err
+	}
+	if cleanTarget != dst && !strings.HasPrefix(cleanTarget, dst+string(os.PathSeparator)) {
+		return "", fmt.Errorf("unsafe zip entry path: %s", name)
+	}
+	return cleanTarget, nil
+}
+
+func extractZipFile(file *zip.File, target string) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return err
+	}
+
+	in, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, file.Mode())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/setup/internal/installer/constants.go
+++ b/setup/internal/installer/constants.go
@@ -4,6 +4,7 @@ const (
 	Version           = "2.0.0"
 	GitHubRepo        = "Swofty-Developments/HypixelSkyBlock"
 	GitHubAPI         = "https://api.github.com/repos/" + GitHubRepo
+	LimboAssetsURL    = "https://files.catbox.moe/oybade.zip"
 	StateFileName     = ".state.json"
 	DefaultInstallSub = ".hypixel-skyblock"
 )

--- a/setup/internal/installer/runner.go
+++ b/setup/internal/installer/runner.go
@@ -85,6 +85,13 @@ func (r *Runner) install(ctx context.Context, cfg Config, sourceConfigDir string
 		}
 	}
 
+	r.emit("Checking for limbo world assets")
+	if err := DownloadLimboAssets(ctx, cfg.InstallDir); err != nil {
+		r.emit("Limbo asset download skipped: %v", err)
+	} else {
+		r.emit("Imported limbo world assets")
+	}
+
 	r.emit("Writing generated Compose and application config")
 	if err := PrepareFiles(cfg); err != nil {
 		return err

--- a/setup/internal/tui/model.go
+++ b/setup/internal/tui/model.go
@@ -230,15 +230,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if ev.Done {
 			m.runDone = true
+			activeEvents = nil
 			if ev.Err == nil {
 				m.logs.SetContent(appendLine(m.logs.View(), "Done. Press Enter to return."))
 				m.logs.GotoBottom()
 			}
+			return m, nil
 		}
 		return m, nextEvent()
 	case logsMsg:
 		m.logs.SetContent(appendLine(m.logs.View(), string(msg)))
 		m.logs.GotoBottom()
+		if string(msg) == "logs ended" {
+			return m, nil
+		}
 		return m, nextLog()
 	case spinner.TickMsg:
 		var cmd tea.Cmd
@@ -844,6 +849,7 @@ func nextEvent() tea.Cmd {
 		}
 		ev, ok := <-activeEvents
 		if !ok {
+			activeEvents = nil
 			return eventMsg{Done: true}
 		}
 		return eventMsg(ev)
@@ -859,6 +865,9 @@ func nextLog() tea.Cmd {
 			return nil
 		}
 		if !activeLogScan.Scan() {
+			_ = activeLogs.Close()
+			activeLogs = nil
+			activeLogScan = nil
 			return logsMsg("logs ended")
 		}
 		return logsMsg(activeLogScan.Text())


### PR DESCRIPTION
- the cache is useless if it happens that late + we already have setup-gradle which does caching as far as I'm aware
- we don't need to check go version every time and make sure it's latest, that probably takes a few seconds
- also bumps checkout and setup-java maybe that does something too
- don't have to chmod the file if it's already executable